### PR TITLE
[Fix #30] return 401 if unauthenticated

### DIFF
--- a/backend/adoorback/adoorback/authentication.py
+++ b/backend/adoorback/adoorback/authentication.py
@@ -1,0 +1,15 @@
+from rest_framework import authentication
+
+
+class SessionAuthentication(authentication.SessionAuthentication):
+    """
+    This class is needed, because REST Framework's default SessionAuthentication does never return 401's,
+    because they cannot fill the WWW-Authenticate header with a valid value in the 401 response. As a
+    result, we cannot distinguish calls that are not unauthorized (401 unauthorized) and calls for which
+    the user does not have permission (403 forbidden). See https://github.com/encode/django-rest-framework/issues/5968
+
+    We do set authenticate_header function in SessionAuthentication, so that a value for the WWW-Authenticate
+    header can be retrieved and the response code is automatically set to 401 in case of unauthenticated requests.
+    """
+    def authenticate_header(self, request):
+        return 'Session'

--- a/backend/adoorback/adoorback/settings/base.py
+++ b/backend/adoorback/adoorback/settings/base.py
@@ -30,7 +30,6 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 15,
     'DEFAULT_AUTHENTICATION_CLASSES': [
-        # 'rest_framework.authentication.SessionAuthentication',
         'adoorback.authentication.SessionAuthentication',
         'rest_framework_simplejwt.authentication.JWTAuthentication',
         'rest_framework.authentication.BasicAuthentication',

--- a/backend/adoorback/adoorback/settings/base.py
+++ b/backend/adoorback/adoorback/settings/base.py
@@ -30,7 +30,8 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 15,
     'DEFAULT_AUTHENTICATION_CLASSES': [
-        'rest_framework.authentication.SessionAuthentication',
+        # 'rest_framework.authentication.SessionAuthentication',
+        'adoorback.authentication.SessionAuthentication',
         'rest_framework_simplejwt.authentication.JWTAuthentication',
         'rest_framework.authentication.BasicAuthentication',
     ],


### PR DESCRIPTION
## What does this PR do?

return 401 instead of 403 if unauthenticated

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code Style Update (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe):

## Further comments

django rest framework가 원래 로그인이 안 되어있을때도 403을 리턴해주도록 설계가 되어있다고 하네요.
어떤 고수분이 간단한 해결책을 제시해주셔서 적용해보았습니다. [고수 url](https://github.com/encode/django-rest-framework/issues/5968#issuecomment-399352828)