### PR TITLE
(#42) 친구 요청 수락 직후, 게시물이 뜨지 않는 오류

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -8,7 +8,8 @@
     "prettier",
     "airbnb",
     "plugin:prettier/recommended",
-    "plugin:react/recommended"
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended"
   ],
   "parser": "@babel/eslint-parser",
   "parserOptions": {

--- a/frontend/src/components/FriendListWidget.jsx
+++ b/frontend/src/components/FriendListWidget.jsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles({
       '0 5px 10px rgba(154, 160, 185, 0.05), 0 5px 10px rgba(166, 173, 201, 0.2)'
   },
   cardContent: {
-    padding: '0 !important'
+    '&:last-child': { paddingBottom: '0 !important' }
   },
   title: {
     fontWeight: 'bold'
@@ -45,7 +45,7 @@ const FriendListWidget = () => {
   }, [dispatch]);
 
   const friendItemList = friendList?.map((friend) => {
-    return <FriendItem key={friend.id} friendObj={friend} isWidget />;
+    return <FriendItem key={friend.id} friendObj={friend} />;
   });
 
   return (

--- a/frontend/src/components/QuestionListWidget.jsx
+++ b/frontend/src/components/QuestionListWidget.jsx
@@ -50,8 +50,8 @@ const WidgetCard = styled(Card)`
 
 const QuestionListItemLink = styled(ListItemLink)`
   border: 1px solid #e7e7e7;
-  margin: 8px;
-  width: calc(100% - 16px);
+  width: 100%;
+  margin: 8px 0;
   border-radius: 4px;
   word-break: break-all;
 `;
@@ -66,7 +66,7 @@ const useStyles = makeStyles((theme) => ({
       '0 5px 10px rgba(154, 160, 185, 0.05), 0 5px 10px rgba(166, 173, 201, 0.2)'
   },
   cardContent: {
-    padding: '0 !important'
+    '&:last-child': { paddingBottom: '0 !important' }
   },
   title: {
     fontWeight: 'bold'

--- a/frontend/src/components/QuestionSendFriendItem.jsx
+++ b/frontend/src/components/QuestionSendFriendItem.jsx
@@ -55,7 +55,7 @@ const QuestionSendFriendItem = ({ questionObj, friendObj, sended }) => {
   };
 
   return (
-    <FriendItemWrapper isWidget={false}>
+    <FriendItemWrapper>
       <FaceIcon />
       <ListItemText
         classes={{ primary: classes.username }}

--- a/frontend/src/components/QuestionSendModal.jsx
+++ b/frontend/src/components/QuestionSendModal.jsx
@@ -70,7 +70,6 @@ const QuestionSendModal = ({ questionObj, open, handleClose }) => {
         key={friend.id}
         questionObj={questionObj}
         friendObj={friend}
-        isWidget
         sended={selectedQuestionResponseRequests?.find(
           (r) => r.requestee_id === friend.id
         )}

--- a/frontend/src/components/SearchDropdownList.jsx
+++ b/frontend/src/components/SearchDropdownList.jsx
@@ -14,6 +14,7 @@ const SearchCard = styled(Card)`
     top: 68px;
     right: 230px;
     z-index: 120;
+    padding: 0 16px;
   }
 
   box-shadow: rgba(0, 0, 0, 0.08) 0px 1px 12px;
@@ -41,12 +42,11 @@ const SearchDropdownList = () => {
   const results = useSelector((state) => state.searchReducer.searchObj.results);
 
   const userList = results?.map((user) => (
-    // FIXME: isWidget 대신 더 의미있는 prop 필요함
-    <FriendItem key={user.id} friendObj={user} isWidget />
+    <FriendItem key={user.id} friendObj={user} />
   ));
 
   return (
-    <SearchCard variant="outlined">
+    <SearchCard variant="outlined" px={2} py={1}>
       <CardContent className={classes.searchDropdownContent}>
         {userList}
       </CardContent>

--- a/frontend/src/components/SearchDropdownList.jsx
+++ b/frontend/src/components/SearchDropdownList.jsx
@@ -41,6 +41,7 @@ const SearchDropdownList = () => {
   const results = useSelector((state) => state.searchReducer.searchObj.results);
 
   const userList = results?.map((user) => (
+    // FIXME: isWidget 대신 더 의미있는 prop 필요함
     <FriendItem key={user.id} friendObj={user} isWidget />
   ));
 

--- a/frontend/src/components/friends/FriendItem.jsx
+++ b/frontend/src/components/friends/FriendItem.jsx
@@ -11,7 +11,7 @@ export const FriendItemWrapper = styled.div`
   align-items: center;
   justify-content: space-between;
   background: #fff;
-  margin: ${(props) => (props.iswidget === 'true' ? '8px 16px' : '8px 0')};
+  margin: ${(props) => (props.isWidget === 'true' ? '8px 16px' : '8px 0')};
   padding: 6px;
   border: 1px solid #e7e7e7;
   border-radius: 4px;
@@ -49,8 +49,8 @@ const FriendItem = ({
   };
 
   return (
-    <FriendItemWrapper iswidget={isWidget.toString()} onClick={onClick}>
-      <FriendLink>
+    <FriendItemWrapper isWidget={isWidget.toString()} onClick={onClick}>
+      <FriendLink onClick={onClick}>
         <FaceIcon />
         <ListItemText
           classes={{ primary: classes.username }}

--- a/frontend/src/components/friends/FriendItem.jsx
+++ b/frontend/src/components/friends/FriendItem.jsx
@@ -11,8 +11,7 @@ export const FriendItemWrapper = styled.div`
   align-items: center;
   justify-content: space-between;
   background: #fff;
-  // FIXME: FriendItem을 래핑하는 컴포넌트에 padding을 넣는 방향 고민하기
-  margin: ${(props) => (props.isWidget ? '8px 16px' : '8px 0')};
+  margin: 8px 0;
   padding: 6px;
   border: 1px solid #e7e7e7;
   border-radius: 4px;
@@ -36,7 +35,6 @@ const useStyles = makeStyles((theme) => ({
 const FriendItem = ({
   friendObj,
   message,
-  isWidget = false,
   showFriendStatus = false,
   isFriend,
   hasSentRequest,
@@ -51,7 +49,7 @@ const FriendItem = ({
   };
 
   return (
-    <FriendItemWrapper isWidget={isWidget.toString()} onClick={onClick}>
+    <FriendItemWrapper onClick={onClick}>
       <FriendLink onClick={onClick}>
         <FaceIcon />
         <ListItemText

--- a/frontend/src/components/friends/FriendItem.jsx
+++ b/frontend/src/components/friends/FriendItem.jsx
@@ -11,7 +11,8 @@ export const FriendItemWrapper = styled.div`
   align-items: center;
   justify-content: space-between;
   background: #fff;
-  margin: ${(props) => (props.isWidget === 'true' ? '8px 16px' : '8px 0')};
+  // FIXME: FriendItem을 래핑하는 컴포넌트에 padding을 넣는 방향 고민하기
+  margin: ${(props) => (props.isWidget ? '8px 16px' : '8px 0')};
   padding: 6px;
   border: 1px solid #e7e7e7;
   border-radius: 4px;
@@ -36,6 +37,7 @@ const FriendItem = ({
   friendObj,
   message,
   isWidget = false,
+  showFriendStatus = false,
   isFriend,
   hasSentRequest,
   isPending
@@ -57,7 +59,7 @@ const FriendItem = ({
           primary={message || username}
         />
       </FriendLink>
-      {!isWidget && (
+      {showFriendStatus && (
         <FriendStatusButtons
           friendObj={friendObj}
           isFriend={isFriend}

--- a/frontend/src/pages/FriendsPage.jsx
+++ b/frontend/src/pages/FriendsPage.jsx
@@ -23,7 +23,14 @@ export default function FriendsPage() {
   }, [dispatch]);
 
   const friendItemList = friendList?.map((friend) => {
-    return <FriendItem key={friend.id} friendObj={friend} isFriend />;
+    return (
+      <FriendItem
+        key={friend.id}
+        friendObj={friend}
+        isFriend
+        showFriendStatus
+      />
+    );
   });
   return (
     <FriendListWrapper>

--- a/frontend/src/pages/NotificationPage.jsx
+++ b/frontend/src/pages/NotificationPage.jsx
@@ -114,6 +114,7 @@ export default function NotificationPage({ tabType }) {
           message={noti.message}
           isPending
           friendObj={noti?.actor_detail}
+          showFriendStatus
         />
       );
     }
@@ -135,6 +136,7 @@ export default function NotificationPage({ tabType }) {
           message={friendRequestNoti.message}
           isPending
           friendObj={friendRequestNoti?.actor_detail}
+          showFriendStatus
         />
       );
     });

--- a/frontend/src/pages/SearchResults.jsx
+++ b/frontend/src/pages/SearchResults.jsx
@@ -48,6 +48,7 @@ export default function SearchResults() {
           isFriend={user.are_friends}
           isPending={user.received_friend_request_from}
           hasSentRequest={user.sent_friend_request_to}
+          showFriendStatus
         />
       );
     });

--- a/frontend/src/pages/UserPage.jsx
+++ b/frontend/src/pages/UserPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { makeStyles } from '@material-ui/core/styles';
 import Tabs from '@material-ui/core/Tabs';
@@ -124,6 +124,15 @@ export default function UserPage() {
     useSelector((state) => state.loadingReducer['user/GET_SELECTED_USER']) ===
     'FAILURE';
 
+  const onIntersect = useCallback(
+    ([entry]) => {
+      if (entry.isIntersecting) {
+        dispatch(appendPosts('selectedUser'));
+      }
+    },
+    [dispatch]
+  );
+
   useEffect(() => {
     dispatch(getSelectedUser(username));
     dispatch(getFriendList());
@@ -133,12 +142,7 @@ export default function UserPage() {
   useEffect(() => {
     if (!selectedUser) return;
     dispatch(getSelectedUserPosts(selectedUser.id));
-  }, [selectedUser]);
-
-  useEffect(() => {
-    dispatch(getSelectedUser(id));
-    dispatch(getSelectedUserPosts(id));
-  }, [friendList]);
+  }, [dispatch, selectedUser, friendList]);
 
   useEffect(() => {
     let observer;
@@ -147,13 +151,7 @@ export default function UserPage() {
       observer.observe(target);
     }
     return () => observer && observer.disconnect();
-  }, [target]);
-
-  const onIntersect = ([entry]) => {
-    if (entry.isIntersecting) {
-      dispatch(appendPosts('selectedUser'));
-    }
-  };
+  }, [target, onIntersect]);
 
   const userResponses = selectedUserPosts?.filter(
     (post) => post.type === 'Response'

--- a/frontend/src/pages/UserPage.jsx
+++ b/frontend/src/pages/UserPage.jsx
@@ -136,6 +136,11 @@ export default function UserPage() {
   }, [selectedUser]);
 
   useEffect(() => {
+    dispatch(getSelectedUser(id));
+    dispatch(getSelectedUserPosts(id));
+  }, [friendList]);
+
+  useEffect(() => {
     let observer;
     if (target) {
       observer = new IntersectionObserver(onIntersect, { threshold: 1 });

--- a/frontend/src/styles.js
+++ b/frontend/src/styles.js
@@ -101,7 +101,7 @@ export const WidgetWrapper = styled.div`
 export const WidgetTitleWrapper = styled.div`
   display: flex;
   justify-content: space-between;
-  padding: 16px;
+  padding-bottom: 16px;
 `;
 
 export const FlexDiv = styled.div`


### PR DESCRIPTION
## Issue Number: #42

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?## What does this PR do?
- 친구 요청 수락 직후, 게시물이 뜨지 않는 오류 수정
  - 친구 리스트에 변화가 있을 때(=친구 수락 직후, 친구 삭제), 사용자 페이지의 친구 상태 버튼과 친구 게시글 목록을 업데이트 하도록 수정
- 기타 리팩토링
  -  `<FriendItem/>`내부의 prop들 정리
    - `<FriendStatusButton/>`이 `isWidget`에 따라 조건부 렌더링 되고 있었는데, 직관적이지 않을 뿐만 아니라, 해당 prop이 `FriendItem`컴포넌트를 감싸고 있던 wrapper 컴포넌트의 스타일링에도 사용되고 있었음
    - `FriendStatusButton`을 렌더링하는 prop 네이밍을 `showFriendStatus` prop으로 바꾸고, 스타일 관련된 사항은 `FriendItem`을 사용하는 wrapper component(`<FriendListWIdget/>`, `<QuestionListWidget/>`, `<SearchDropdownList/>`에서 설정하도록 변경

## Preview Image
![Oct-30-2022 17-56-44](https://user-images.githubusercontent.com/37523788/198870738-ee589912-9d49-44e0-b68e-f5ed5c834321.gif)
