### PR TITLE
(#82) [유저페이지] users/:id -> users/:username으로 변경하기(프론트)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -101,7 +101,7 @@ const App = () => {
             <PrivateRoute exact path="/home" component={FriendFeed} />
             <PrivateRoute exact path="/anonymous" component={AnonymousFeed} />
             <PrivateRoute exact path="/questions" component={QuestionFeed} />
-            <PrivateRoute exact path="/users/:id" component={UserPage} />
+            <PrivateRoute exact path="/users/:username" component={UserPage} />
             <PrivateRoute
               exact
               path="/notifications"
@@ -143,7 +143,7 @@ const App = () => {
               path="/user-search"
               component={MobileSearchPage}
             />
-            <Redirect from="/my-page" to={`/users/${currentUser?.id}`} />
+            <Redirect from="/my-page" to={`/users/${currentUser?.username}`} />
             <Redirect exact path="/" to="/home" />
           </Switch>
         </FeedWrapper>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -289,10 +289,10 @@ const Header = ({ isMobile }) => {
           disableRipple
           color="secondary"
         >
-          <Link to={`/users/${currentUser?.id}`}>
+          <Link to={`/users/${currentUser?.username}`}>
             <AccountCircle color="secondary" />
           </Link>
-          <Link to={`/users/${currentUser?.id}`}>
+          <Link to={`/users/${currentUser?.username}`}>
             <HelloUsername className="hello-username">
               {currentUser?.username}
             </HelloUsername>

--- a/frontend/src/components/friends/FriendItem.jsx
+++ b/frontend/src/components/friends/FriendItem.jsx
@@ -49,8 +49,8 @@ const FriendItem = ({
   };
 
   return (
-    <FriendItemWrapper iswidget={isWidget.toString()}>
-      <FriendLink onClick={onClick}>
+    <FriendItemWrapper iswidget={isWidget.toString()} onClick={onClick}>
+      <FriendLink>
         <FaceIcon />
         <ListItemText
           classes={{ primary: classes.username }}

--- a/frontend/src/components/friends/FriendItem.jsx
+++ b/frontend/src/components/friends/FriendItem.jsx
@@ -43,9 +43,14 @@ const FriendItem = ({
   const classes = useStyles();
   const history = useHistory();
   const { username } = friendObj;
+
+  const onClick = () => {
+    history.push(`/users/${username}`);
+  };
+
   return (
     <FriendItemWrapper iswidget={isWidget.toString()}>
-      <FriendLink onClick={() => history.push(`/users/${friendObj.id}`)}>
+      <FriendLink onClick={onClick}>
         <FaceIcon />
         <ListItemText
           classes={{ primary: classes.username }}

--- a/frontend/src/components/posts/AuthorProfile.jsx
+++ b/frontend/src/components/posts/AuthorProfile.jsx
@@ -30,8 +30,9 @@ export default function AuthorProfile({
   const { id, username, profile_pic: picHex, color_hex: hex } = author;
 
   const onClickProfile = () => {
-    if (id) history.push(`/users/${id}`);
+    history.push(`/users/${username}`);
   };
+
   return (
     <AuthorProfileWrapper onClick={onClickProfile}>
       {id && (!isAnonFeed || isAuthor) ? (

--- a/frontend/src/modules/post.js
+++ b/frontend/src/modules/post.js
@@ -167,11 +167,11 @@ export const getPostsByType =
     });
   };
 
-export const getSelectedUserPosts = (userId) => async (dispatch) => {
+export const getSelectedUserPosts = (username) => async (dispatch) => {
   let result;
-  dispatch({ type: `post/GET_USER_POSTS_REQUEST`, userId });
+  dispatch({ type: `post/GET_USER_POSTS_REQUEST`, username });
   try {
-    result = await axios.get(`feed/user/${userId}/`);
+    result = await axios.get(`feed/user/${username}/`);
   } catch (error) {
     dispatch({ type: `post/GET_USER_POSTS_FAILURE`, error });
     return;

--- a/frontend/src/modules/post.js
+++ b/frontend/src/modules/post.js
@@ -167,11 +167,11 @@ export const getPostsByType =
     });
   };
 
-export const getSelectedUserPosts = (username) => async (dispatch) => {
+export const getSelectedUserPosts = (id) => async (dispatch) => {
   let result;
-  dispatch({ type: `post/GET_USER_POSTS_REQUEST`, username });
+  dispatch({ type: `post/GET_USER_POSTS_REQUEST`, id });
   try {
-    result = await axios.get(`feed/user/${username}/`);
+    result = await axios.get(`feed/user/${id}/`);
   } catch (error) {
     dispatch({ type: `post/GET_USER_POSTS_FAILURE`, error });
     return;

--- a/frontend/src/modules/user.js
+++ b/frontend/src/modules/user.js
@@ -192,11 +192,11 @@ export const getCurrentUser = () => async (dispatch) => {
   }
 };
 
-export const getSelectedUser = (id) => async (dispatch) => {
+export const getSelectedUser = (userName) => async (dispatch) => {
   let result;
   dispatch({ type: `user/GET_SELECTED_USER_REQUEST` });
   try {
-    result = await axios.get(`user/${id}/`);
+    result = await axios.get(`user/profile/${userName}/`);
   } catch (error) {
     dispatch({ type: `user/GET_SELECTED_USER_FAILURE`, error });
     return;

--- a/frontend/src/pages/UserPage.jsx
+++ b/frontend/src/pages/UserPage.jsx
@@ -132,7 +132,7 @@ export default function UserPage() {
 
   useEffect(() => {
     if (!selectedUser) return;
-    dispatch(getSelectedUserPosts(selectedUser.username));
+    dispatch(getSelectedUserPosts(selectedUser.id));
   }, [selectedUser]);
 
   useEffect(() => {

--- a/frontend/src/pages/UserPage.jsx
+++ b/frontend/src/pages/UserPage.jsx
@@ -94,7 +94,7 @@ const useStyles = makeStyles((theme) => ({
 
 export default function UserPage() {
   const [target, setTarget] = useState(null);
-  const { id } = useParams();
+  const { username } = useParams();
   const dispatch = useDispatch();
   const classes = useStyles();
   const selectedUser = useSelector((state) => state.userReducer.selectedUser);
@@ -125,11 +125,15 @@ export default function UserPage() {
     'FAILURE';
 
   useEffect(() => {
-    dispatch(getSelectedUser(id));
+    dispatch(getSelectedUser(username));
     dispatch(getFriendList());
-    dispatch(getSelectedUserPosts(id));
     setValue('All');
-  }, [dispatch, id]);
+  }, [dispatch, username]);
+
+  useEffect(() => {
+    if (!selectedUser) return;
+    dispatch(getSelectedUserPosts(selectedUser.username));
+  }, [selectedUser]);
 
   useEffect(() => {
     let observer;
@@ -163,8 +167,9 @@ export default function UserPage() {
   };
 
   const onClickConfirmBlockUser = async () => {
+    if (!selectedUser) return;
     await axios.post('/user_reports/', {
-      reported_user_id: id
+      reported_user_id: selectedUser.id
     });
   };
 
@@ -174,8 +179,9 @@ export default function UserPage() {
   };
 
   const onClickConfirmReportUser = async () => {
+    if (!selectedUser) return;
     await axios.post('/user_reports/', {
-      reported_user_id: id
+      reported_user_id: selectedUser.id
     });
   };
 

--- a/frontend/src/pages/UserPage.jsx
+++ b/frontend/src/pages/UserPage.jsx
@@ -245,7 +245,7 @@ export default function UserPage() {
                   color: selectedUser?.profile_pic
                 }}
               />
-              <h3 margin-bottom="10px">{selectedUser?.username}</h3>
+              <h3 style={{ marginBottom: '10px' }}>{selectedUser?.username}</h3>
               <div>
                 {selectedUser && (
                   <FriendStatusButtons


### PR DESCRIPTION
## Issue Number: #82

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?## What does this PR do?
- /users/:id -> /users/:username 라우트 변경
- getSelectedUser에서 /user/profile/:username api 호출하도록 변경
-  헤더 현재 유저 링크 변경
- <FriendItem/> 링크 변경
  - 헤더 검색 결과 드랍다운, 친구 위젯, 사용자 검색 결과 페이지, 노티 페이지, 친구 목록 페이지, 질문 전송 페이지
- 글쓴이 클릭시 링크 변경

## Preview Image
![image](https://user-images.githubusercontent.com/37523788/200156911-5254c409-85bb-4fc3-ad4b-d59446f03da9.png)

