### PR TITLE
(#91) [사용자 검색] 모바일에서 검색된 유저가 클릭되지 않음

### DIFF
--- a/frontend/src/components/friends/FriendItem.jsx
+++ b/frontend/src/components/friends/FriendItem.jsx
@@ -49,8 +49,8 @@ const FriendItem = ({
   };
 
   return (
-    <FriendItemWrapper iswidget={isWidget.toString()}>
-      <FriendLink onClick={onClick}>
+    <FriendItemWrapper iswidget={isWidget.toString()} onClick={onClick}>
+      <FriendLink>
         <FaceIcon />
         <ListItemText
           classes={{ primary: classes.username }}


### PR DESCRIPTION
## Issue Number: #91

## Self Check List
⭐️userpage url 변경 작업과도 관련이 있어서 userpage-front`에 머지하려고 합니다! 이 PR이 머지된 이후 userpage-front->userpage 머지하겠습니다!!⭐️
- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?## What does this PR do?
- 모바일 검색 페이지(/users/user-search)에서 사용자 아이템을 클릭시에 해당 사용자 페이지로 이동하지 않는 버그 수정
  - 사용자 아이템(`FriendItem`)의 사용자 이름 text영역 이외의 여백 공간을 클릭하면 이동되지 않는 버그였습니다(현재도 텍스트 영역 터치 시에는 이동됩니다)
![Nov-06-2022 15-23-05](https://user-images.githubusercontent.com/37523788/200157488-0ccda9b4-d96e-485d-a984-ccd012ca98eb.gif)

  - 텍스트 영역이 아닌 아이템 자체를 클릭해도 이동될 수 있도록 수정했습니다

## Preview Image
![Nov-06-2022 15-22-56](https://user-images.githubusercontent.com/37523788/200157500-2208556b-8d69-4a05-b15a-30b048386b48.gif)
