### PR TITLE
(#3) 노티 페이지 질문 노출 오류

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -109,18 +109,6 @@ const App = () => {
             />
             <PrivateRoute
               exact
-              path="/notifications/friend-request"
-              component={NotificationPage}
-              tabType="FriendRequest"
-            />
-            <PrivateRoute
-              exact
-              path="/notifications/response-request"
-              component={NotificationPage}
-              tabType="ResponseRequest"
-            />
-            <PrivateRoute
-              exact
               path="/questions/:id"
               component={QuestionDetail}
             />

--- a/frontend/src/modules/notification.js
+++ b/frontend/src/modules/notification.js
@@ -2,6 +2,8 @@ import axios from '../apis';
 
 const initialState = {
   receivedNotifications: [],
+  receivedFriendRequests: [],
+  receivedResponseRequests: [],
   next: null
 };
 
@@ -19,6 +21,34 @@ export const APPEND_NOTIFICATIONS_SUCCESS =
 export const APPEND_NOTIFICATIONS_FAILURE =
   'notification/APPEND_NOTIFICATION_FAILURE';
 
+export const GET_FRIEND_REQUESTS_REQUEST =
+  'notification/GET_FRIEND_REQUESTS_REQUEST';
+export const GET_FRIEND_REQUESTS_SUCCESS =
+  'FRIEND_REQUESTS/GET_FRIEND_REQUESTS_SUCCESS';
+export const GET_FRIEND_REQUESTS_FAILURE =
+  'FRIEND_REQUESTS/GET_FRIEND_REQUESTS_FAILURE';
+
+export const APPEND_FRIEND_REQUESTS_REQUEST =
+  'FRIEND_REQUESTS/APPEND_FRIEND_REQUESTS_REQUEST';
+export const APPEND_FRIEND_REQUESTS_SUCCESS =
+  'FRIEND_REQUESTS/APPEND_FRIEND_REQUESTS_SUCCESS';
+export const APPEND_FRIEND_REQUESTS_FAILURE =
+  'FRIEND_REQUESTS/APPEND_FRIEND_REQUESTS_FAILURE';
+
+export const GET_RESPONSE_REQUESTS_REQUEST =
+  'notification/GET_RESPONSE_REQUESTS_REQUEST';
+export const GET_RESPONSE_REQUESTS_SUCCESS =
+  'RESPONSE_REQUESTS/GET_RESPONSE_REQUESTS_SUCCESS';
+export const GET_RESPONSE_REQUESTS_FAILURE =
+  'RESPONSE_REQUESTS/GET_RESPONSE_REQUESTS_FAILURE';
+
+export const APPEND_RESPONSE_REQUESTS_REQUEST =
+  'RESPONSE_REQUESTS/APPEND_RESPONSE_REQUESTS_REQUEST';
+export const APPEND_RESPONSE_REQUESTS_SUCCESS =
+  'RESPONSE_REQUESTS/APPEND_RESPONSE_REQUESTS_SUCCESS';
+export const APPEND_RESPONSE_REQUESTS_FAILURE =
+  'RESPONSE_REQUESTS/APPEND_NOTIFICATION_FAILURE';
+
 export const READ_NOTIFICATION_REQUEST =
   'notification/READ_NOTIFICATION_REQUEST';
 export const READ_NOTIFICATION_SUCCESS =
@@ -33,22 +63,20 @@ export const READ_ALL_NOTIFICATIONS_SUCCESS =
 export const READ_ALL_NOTIFICATIONS_FAILURE =
   'notification/READ_ALL_NOTIFICATIONS_FAILURE';
 
-export const DELETE_NOTIFICATION_REQUEST = '';
-
 export const getNotifications = () => async (dispatch) => {
   let res;
-  dispatch({ type: 'notification/GET_NOTIFICATION_REQUEST' });
+  dispatch({ type: GET_NOTIFICATIONS_REQUEST });
   try {
     res = await axios.get('/notifications/');
   } catch (error) {
     dispatch({
-      type: 'notification/GET_NOTIFICATION_FAILURE',
+      type: GET_NOTIFICATIONS_FAILURE,
       error
     });
     return;
   }
   dispatch({
-    type: 'notification/GET_NOTIFICATION_SUCCESS',
+    type: GET_NOTIFICATIONS_SUCCESS,
     res: res?.data.results,
     next: res?.data.next
   });
@@ -69,6 +97,84 @@ export const appendNotifications = () => async (dispatch, getState) => {
   const { data } = result;
   dispatch({
     type: APPEND_NOTIFICATIONS_SUCCESS,
+    results: data?.results,
+    next: data?.next
+  });
+};
+
+export const getFriendRequests = () => async (dispatch) => {
+  let res;
+  dispatch({ type: GET_FRIEND_REQUESTS_REQUEST });
+  try {
+    res = await axios.get('/notifications/friend-requests/');
+  } catch (error) {
+    dispatch({
+      type: GET_FRIEND_REQUESTS_FAILURE,
+      error
+    });
+    return;
+  }
+  dispatch({
+    type: GET_FRIEND_REQUESTS_SUCCESS,
+    res: res?.data.results,
+    next: res?.data.next
+  });
+};
+
+export const appendFriendRequests = () => async (dispatch, getState) => {
+  const { next } = getState().notiReducer;
+  if (!next) return;
+  const nextUrl = next.replace('http://localhost:8000/api/', '');
+  let result;
+  dispatch({ type: APPEND_FRIEND_REQUESTS_REQUEST });
+  try {
+    result = await axios.get(nextUrl);
+  } catch (error) {
+    dispatch({ type: APPEND_FRIEND_REQUESTS_FAILURE, error });
+    return;
+  }
+  const { data } = result;
+  dispatch({
+    type: APPEND_FRIEND_REQUESTS_SUCCESS,
+    results: data?.results,
+    next: data?.next
+  });
+};
+
+export const getResponseRequests = () => async (dispatch) => {
+  let res;
+  dispatch({ type: GET_RESPONSE_REQUESTS_REQUEST });
+  try {
+    res = await axios.get('/notifications/response-requests/');
+  } catch (error) {
+    dispatch({
+      type: GET_RESPONSE_REQUESTS_FAILURE,
+      error
+    });
+    return;
+  }
+  dispatch({
+    type: GET_RESPONSE_REQUESTS_SUCCESS,
+    res: res?.data.results,
+    next: res?.data.next
+  });
+};
+
+export const appendResponseRequests = () => async (dispatch, getState) => {
+  const { next } = getState().notiReducer;
+  if (!next) return;
+  const nextUrl = next.replace('http://localhost:8000/api/', '');
+  let result;
+  dispatch({ type: APPEND_RESPONSE_REQUESTS_REQUEST });
+  try {
+    result = await axios.get(nextUrl);
+  } catch (error) {
+    dispatch({ type: APPEND_RESPONSE_REQUESTS_FAILURE, error });
+    return;
+  }
+  const { data } = result;
+  dispatch({
+    type: APPEND_RESPONSE_REQUESTS_SUCCESS,
     results: data?.results,
     next: data?.next
   });
@@ -137,6 +243,34 @@ export default function notiReducer(state, action) {
         ...state,
         receivedNotifications: state.receivedNotifications
           ? [...state.receivedNotifications, ...action.results]
+          : [...action.results],
+        next: action.next
+      };
+    case GET_FRIEND_REQUESTS_SUCCESS:
+      return {
+        ...state,
+        receivedFriendRequests: action.res,
+        next: action.next
+      };
+    case APPEND_FRIEND_REQUESTS_SUCCESS:
+      return {
+        ...state,
+        receivedFriendRequests: state.receivedFriendRequests
+          ? [...state.receivedFriendRequests, ...action.results]
+          : [...action.results],
+        next: action.next
+      };
+    case GET_RESPONSE_REQUESTS_SUCCESS:
+      return {
+        ...state,
+        receivedResponseRequests: action.res,
+        next: action.next
+      };
+    case APPEND_RESPONSE_REQUESTS_SUCCESS:
+      return {
+        ...state,
+        receivedResponseRequests: state.receivedResponseRequests
+          ? [...state.receivedResponseRequests, ...action.results]
           : [...action.results],
         next: action.next
       };

--- a/frontend/src/pages/NotificationPage.jsx
+++ b/frontend/src/pages/NotificationPage.jsx
@@ -66,11 +66,18 @@ const useStyles = makeStyles((theme) => ({
   }
 }));
 
+// FIXME: ts 전환시 readonly로 대체
+const NOTIFICATION_TABS = {
+  ALL: { name: '전체', index: 0 },
+  FRIEND_REQUEST: { name: '친구 요청', index: 1 },
+  RESPONSE_REQUEST: { name: '받은 질문', index: 2 }
+};
+
 export default function NotificationPageNotificationPage() {
   const dispatch = useDispatch();
 
   const [target, setTarget] = useState(null);
-  const [tab, setTab] = useState(0);
+  const [tab, setTab] = useState(NOTIFICATION_TABS.ALL.index);
 
   const classes = useStyles();
 
@@ -96,13 +103,13 @@ export default function NotificationPageNotificationPage() {
 
   const fetchNotifications = useCallback(() => {
     switch (tab) {
-      case 0: // all
+      case NOTIFICATION_TABS.ALL.index:
         dispatch(getNotifications());
         break;
-      case 1: // friend requests
+      case NOTIFICATION_TABS.FRIEND_REQUEST.index:
         dispatch(getFriendRequests());
         break;
-      case 2: // response requests
+      case NOTIFICATION_TABS.RESPONSE_REQUEST.index:
         dispatch(getResponseRequests());
         break;
       default:
@@ -113,13 +120,13 @@ export default function NotificationPageNotificationPage() {
     ([entry]) => {
       if (entry.isIntersecting) {
         switch (tab) {
-          case 0: // all
+          case NOTIFICATION_TABS.ALL.index:
             dispatch(appendNotifications());
             break;
-          case 1: // friend requests
+          case NOTIFICATION_TABS.FRIEND_REQUEST.index:
             dispatch(appendFriendRequests());
             break;
-          case 2: // response requests
+          case NOTIFICATION_TABS.RESPONSE_REQUEST.index:
             dispatch(appendResponseRequests());
             break;
           default:
@@ -197,9 +204,13 @@ export default function NotificationPageNotificationPage() {
           indicatorColor="primary"
           textColor="primary"
         >
-          <Tab label="전체" {...a11yProps(0)} />
-          <Tab label="친구 요청" {...a11yProps(1)} />
-          <Tab label="받은 질문" {...a11yProps(2)} />
+          {Object.values(NOTIFICATION_TABS).map((tabItem) => (
+            <Tab
+              key={tabItem.index}
+              label={tabItem.name}
+              {...a11yProps(tabItem.index)}
+            />
+          ))}
         </Tabs>
       </AppBar>
       <ButtonWrapper>
@@ -212,15 +223,27 @@ export default function NotificationPageNotificationPage() {
           모두 읽음
         </Button>
       </ButtonWrapper>
-      <TabPanel value={tab} index={0} className={classes.tabPanel}>
+      <TabPanel
+        value={tab}
+        index={NOTIFICATION_TABS.ALL.index}
+        className={classes.tabPanel}
+      >
         {notificationList}
         <div ref={setTarget} />
       </TabPanel>
-      <TabPanel value={tab} index={1} className={classes.tabPanel}>
+      <TabPanel
+        value={tab}
+        index={NOTIFICATION_TABS.FRIEND_REQUEST.index}
+        className={classes.tabPanel}
+      >
         {friendRequestList}
         <div ref={setTarget} />
       </TabPanel>
-      <TabPanel value={tab} index={2} className={classes.tabPanel}>
+      <TabPanel
+        value={tab}
+        index={NOTIFICATION_TABS.RESPONSE_REQUEST.index}
+        className={classes.tabPanel}
+      >
         {responseRequestList}
         <div ref={setTarget} />
       </TabPanel>


### PR DESCRIPTION
## Issue Number: #3

## Self Check List
- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?## What does this PR do?
- 노티 페이지의 받은 질문 탭에서 받은 질문이 일부만 보이는 버그 수정
  - 받은 질문 뿐만 아니라, 친구 요청도 일부만 노출될 가능성이 있었음(전체 노티 15개 중 포함되지 않는 받은질문/친구요청 노티는 각 탭에서 노출 되고 있지 않았음)
  - 받은 질문, 친구 요청 각각에 대한 redux state, fetch/append와 관련된 redux action 추가(42461de0a499eb544187d9d0e6785bdb0b272f02)
  

> p.s 간만에 redux 코드 작성하려고 하니 템플릿 코드가 너무 많아서 빨리 react-query 도입하고 싶은 마음이 굴뚝같아졌네요..🥺

  - '전체' 탭 이외의 탭('받은 질문', '친구 요청')에도 infinite scroll 적용(0194c90b5b7c31e1923d56e93a62dc3660223e9b)
- 기타
  - 사용되지 않고 있던 /notification 관련 route(/notification/friend-request, /notification/response-request) 삭제(3e859c019558caefb452db69223a8eb89cd8d275)

## Preview Image
![Nov-16-2022 22-19-52](https://user-images.githubusercontent.com/37523788/202191338-f9962551-6d1a-4958-9876-bd43934725d0.gif)