### PR TITLE
(#103) uwsgi 설정 변경

### DIFF
--- a/backend/adoorback/.config/uwsgi/uwsgi.ini
+++ b/backend/adoorback/.config/uwsgi/uwsgi.ini
@@ -2,8 +2,11 @@
 chdir = /home/ubuntu/adoor/backend/adoorback
 module = adoorback.wsgi:application
 home = /home/ubuntu/venv
-http = : 8000
+http = 0.0.0.0:8000
 master = true
 vacuum = true
 pidfile = /tmp/adoorback.pid
-daemonize = /var/log/uwsgi/adoorback.log
+logto = /var/log/uwsgi/adoorback_uwsgi.log
+for-readline = /home/ubuntu/adoor/backend/adoorback/.config/uwsgi/env
+  env = %(_)
+endfor =


### PR DESCRIPTION
## Issue Number: #103 

## Self Check List
- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
`systemctl` 명령어로 `uwsgi` 를 실행하고 제어할 수 있도록 설정 변경
1. `deamonize` -> `logto` 변경
  L `daemonize` 설정은 특정 파일에 서버 로그를 적는 역할을 하는데, 이 설정으로 인하여 `systemd` 프로세스가 `uwsgi`의 신호를 받지 못하여  `systemctl start uwsgi` 명령으로 `uwsgi` 가 실행되지 않는 문제가 있었음
  L 같은 역할을 하는 `logto` 설정으로 변경
  L 설정 변경 이전의 로그는 `/var/log/uwsgi/adoorback.log` 파일에 보존하고, 설정 변경 이후의 로그는 `/var/log/uwsgi/adoorback_uwsgi.log` 에 기록되도록 설정

2. 환경변수 설정
  L 환경변수 설정이 되어 있지 않아 `/home/ubuntu/adoor/backend/adoorback/.config/uwsgi/env` 에 환경변수를 작성하고 `uwsgi.ini` 파일이 이 파일로부터 환경변수를 읽어오도록 설정
  L 환경변수가 깃헙에 노출되지 않도록 `/home/ubuntu/adoor/backend/adoorback/.config/uwsgi/env` 파일은 깃으로 관리하지 않고 배포 환경에만 저장
  
해당 설정으로 백엔드 배포 시도 후 이상 없음을 확인하였습니다 