### PR TITLE
(#2) 노티 창 오픈 시 모두 읽음 처리

### DIFF
--- a/frontend/src/components/NotificationDropdownList.jsx
+++ b/frontend/src/components/NotificationDropdownList.jsx
@@ -12,6 +12,8 @@ import ListItemText from '@material-ui/core/ListItemText';
 import { readAllNotification } from '../modules/notification';
 import NotificationItem from './NotificationItem';
 
+const READ_ALL_NOTI_DELAY = 300;
+
 const useStyles = makeStyles({
   notificationDropdown: {
     width: 300,
@@ -68,7 +70,7 @@ const NotificationDropdownList = ({ notifications, setIsNotiOpen }) => {
   useEffect(() => {
     setTimeout(() => {
       dispatch(readAllNotification());
-    }, 300);
+    }, READ_ALL_NOTI_DELAY);
   }, []);
 
   return (

--- a/frontend/src/components/NotificationDropdownList.jsx
+++ b/frontend/src/components/NotificationDropdownList.jsx
@@ -71,7 +71,7 @@ const NotificationDropdownList = ({ notifications, setIsNotiOpen }) => {
     setTimeout(() => {
       dispatch(readAllNotification());
     }, READ_ALL_NOTI_DELAY);
-  }, []);
+  }, [dispatch]);
 
   return (
     <Card variant="outlined" className={classes.notificationDropdown}>

--- a/frontend/src/components/NotificationDropdownList.jsx
+++ b/frontend/src/components/NotificationDropdownList.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/button-has-type */
-import React from 'react';
+import React, { useEffect } from 'react';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import { makeStyles } from '@material-ui/core/styles';
@@ -50,7 +50,6 @@ const ButtonWrapper = styled.div`
   align-items: center;
   justify-content: space-between;
   padding: 4px 16px 0px 16px;
-}
 `;
 
 const NotificationDropdownList = ({ notifications, setIsNotiOpen }) => {
@@ -66,9 +65,12 @@ const NotificationDropdownList = ({ notifications, setIsNotiOpen }) => {
     />
   ));
 
-  const handleReadAllNotification = () => {
-    dispatch(readAllNotification());
-  };
+  useEffect(() => {
+    setTimeout(() => {
+      dispatch(readAllNotification());
+    }, 300);
+  }, []);
+
   return (
     <Card variant="outlined" className={classes.notificationDropdown}>
       <ButtonWrapper>
@@ -82,14 +84,6 @@ const NotificationDropdownList = ({ notifications, setIsNotiOpen }) => {
         >
           알림 전체 보기
         </button>
-        {notifications?.length !== 0 && (
-          <button
-            className={`read-all-notifications ${classes.notiButtons}`}
-            onClick={handleReadAllNotification}
-          >
-            모두 읽음
-          </button>
-        )}
       </ButtonWrapper>
       {notifications?.length === 0 ? (
         <ListItem>

--- a/frontend/src/components/NotificationDropdownList.test.jsx
+++ b/frontend/src/components/NotificationDropdownList.test.jsx
@@ -43,15 +43,6 @@ describe('<NotificationDropdownList/>', () => {
     expect(mockFn).toHaveBeenCalled();
   });
 
-  it(`should call 'handleReadAllNotification' when click read all notification button`, () => {
-    const component = wrapper.find('NotificationDropdownList');
-    const allNotiButton = component.find('.read-all-notifications');
-
-    expect(allNotiButton.length).toBe(1);
-    allNotiButton.simulate('click', { stopPropagation: () => undefined });
-    expect(mockFn).toHaveBeenCalled();
-  });
-
   it('should not render buttons when notifications are empty', () => {
     const emptyNotiWrapper = mount(
       <Provider store={store}>

--- a/frontend/src/components/NotificationItem.jsx
+++ b/frontend/src/components/NotificationItem.jsx
@@ -5,8 +5,6 @@ import ListItem from '@material-ui/core/ListItem';
 import { useHistory } from 'react-router-dom';
 import FaceIcon from '@material-ui/icons/Face';
 import styled from 'styled-components';
-import { useDispatch } from 'react-redux';
-import { readNotification } from '../modules/notification';
 import { getCreatedTime } from '../utils/dateTimeHelpers';
 
 const useStyles = makeStyles((theme) => ({
@@ -64,11 +62,9 @@ const NotiCreatedAt = styled.div`
 // eslint-disable-next-line react/prop-types
 const NotificationItem = ({ notiObj, isNotificationPage }) => {
   const classes = useStyles();
-  const dispatch = useDispatch();
   const history = useHistory();
 
   const handleClickNotiItem = () => {
-    dispatch(readNotification(notiObj.id));
     history.push(notiObj.redirect_url);
   };
 
@@ -80,6 +76,7 @@ const NotificationItem = ({ notiObj, isNotificationPage }) => {
         !notiObj.is_read && classes.unread
       } ${classes.notiLink} ${classes.listItemWrapper}`}
       onClick={handleClickNotiItem}
+      style={{ transition: '.5s' }}
     >
       <MessageWrapper>
         {actor_detail?.id ? (

--- a/frontend/src/components/NotificationItem.test.jsx
+++ b/frontend/src/components/NotificationItem.test.jsx
@@ -5,13 +5,11 @@ import { Router } from 'react-router-dom';
 import { createStore, applyMiddleware } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import thunk from 'redux-thunk';
-import { act } from 'react-dom/test-utils';
 import { mockNotiArrays } from '../constants';
 import NotificationItem from './NotificationItem';
 import { mockStore } from '../mockStore';
 import rootReducer from '../modules';
 import history from '../history';
-import * as actionCreators from '../modules/notification';
 
 describe('<NotificationItem/>', () => {
   const store = createStore(
@@ -31,22 +29,5 @@ describe('<NotificationItem/>', () => {
   it('should render without errors', () => {
     const component = wrapper.find('NotificationItem');
     expect(component).toHaveLength(1);
-  });
-
-  it('should handle noti click', async () => {
-    const component = wrapper.find('NotificationItem');
-
-    const readNotification = jest
-      .spyOn(actionCreators, 'readNotification')
-      .mockImplementation(() => {
-        // eslint-disable-next-line no-unused-vars
-        return (dispatch) => {};
-      });
-
-    await act(async () => {
-      component.simulate('click');
-    });
-
-    expect(readNotification).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/modules/notification.js
+++ b/frontend/src/modules/notification.js
@@ -49,13 +49,6 @@ export const APPEND_RESPONSE_REQUESTS_SUCCESS =
 export const APPEND_RESPONSE_REQUESTS_FAILURE =
   'RESPONSE_REQUESTS/APPEND_NOTIFICATION_FAILURE';
 
-export const READ_NOTIFICATION_REQUEST =
-  'notification/READ_NOTIFICATION_REQUEST';
-export const READ_NOTIFICATION_SUCCESS =
-  'notification/READ_NOTIFICATION_SUCCESS';
-export const READ_NOTIFICATION_FAILURE =
-  'notification/READ_NOTIFICATION_FAILURE';
-
 export const READ_ALL_NOTIFICATIONS_REQUEST =
   'notification/READ_ALL_NOTIFICATIONS_REQUEST';
 export const READ_ALL_NOTIFICATIONS_SUCCESS =
@@ -180,21 +173,6 @@ export const appendResponseRequests = () => async (dispatch, getState) => {
   });
 };
 
-export const readNotification = (id) => async (dispatch) => {
-  let res;
-  dispatch({ type: 'notification/READ_NOTIFICATION_REQUEST' });
-  try {
-    res = await axios.patch(`/notifications/${id}/`, { is_read: true });
-  } catch (error) {
-    dispatch({ type: 'notification/READ_NOTIFICATION_FAILURE', error });
-    return;
-  }
-  dispatch({
-    type: 'notification/READ_NOTIFICATION_SUCCESS',
-    res: res.data
-  });
-};
-
 export const readAllNotification = () => async (dispatch) => {
   let res;
   dispatch({ type: 'notification/READ_ALL_NOTIFICATIONS_REQUEST' });
@@ -224,19 +202,6 @@ export default function notiReducer(state, action) {
         ...state,
         receivedNotifications: action.res,
         next: action.next
-      };
-    case READ_NOTIFICATION_SUCCESS:
-      const updatedNotification = action.res;
-      const updatedNotificationIndex = state.receivedNotifications.findIndex(
-        (noti) => noti.id === updatedNotification.id
-      );
-      return {
-        ...state,
-        receivedNotifications: [
-          ...state.receivedNotifications.slice(0, updatedNotificationIndex),
-          updatedNotification,
-          ...state.receivedNotifications.slice(updatedNotificationIndex + 1)
-        ]
       };
     case APPEND_NOTIFICATIONS_SUCCESS:
       return {

--- a/frontend/src/modules/notification.test.js
+++ b/frontend/src/modules/notification.test.js
@@ -59,28 +59,6 @@ describe('notificationActions', () => {
     });
   });
 
-  it(`'readNotification' should get notification correctly`, (done) => {
-    jest.clearAllMocks();
-    jest.mock('axios');
-    const spy = jest.spyOn(axios, 'patch').mockImplementation(() => {
-      return new Promise((resolve) => {
-        const res = {
-          data: 'updatedNotification'
-        };
-        resolve(res);
-      });
-    });
-
-    store.dispatch(actionCreators.readNotification()).then(() => {
-      const newState = store.getState();
-      expect(spy).toHaveBeenCalled();
-      expect(newState.notiReducer.receivedNotifications).toEqual([
-        'updatedNotification'
-      ]);
-      done();
-    });
-  });
-
   it(`'readAllNotification' should get notification correctly`, (done) => {
     jest.mock('axios');
 
@@ -110,21 +88,6 @@ describe('notificationActions', () => {
     });
 
     store.dispatch(actionCreators.getNotifications()).then(() => {
-      const newState = store.getState();
-      expect(spy).toHaveBeenCalled();
-      expect(newState.notiReducer.receivedNotifications).toMatchObject(
-        mockNotifications
-      );
-    });
-  });
-
-  it(`should dispatch notification/READ_NOTIFICATION_FAILURE when api returns error`, async () => {
-    jest.mock('axios');
-    const spy = jest.spyOn(axios, 'patch').mockImplementation(() => {
-      return Promise.reject(new Error('error'));
-    });
-
-    store.dispatch(actionCreators.readNotification()).then(() => {
       const newState = store.getState();
       expect(spy).toHaveBeenCalled();
       expect(newState.notiReducer.receivedNotifications).toMatchObject(

--- a/frontend/src/pages/NotificationPage.jsx
+++ b/frontend/src/pages/NotificationPage.jsx
@@ -5,8 +5,6 @@ import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import Box from '@material-ui/core/Box';
-import styled from 'styled-components';
-import { Button } from '@material-ui/core';
 import NotificationItem from '../components/NotificationItem';
 import FriendItem from '../components/friends/FriendItem';
 import {
@@ -42,11 +40,6 @@ function a11yProps(index) {
     'aria-controls': `simple-tabpanel-${index}`
   };
 }
-
-const ButtonWrapper = styled.div`
-  display: flex;
-  flex-direction: row-reverse;
-`;
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -97,10 +90,6 @@ export default function NotificationPageNotificationPage() {
     setTab(newValue);
   };
 
-  const handleReadAllNotification = () => {
-    dispatch(readAllNotification());
-  };
-
   const fetchNotifications = useCallback(() => {
     switch (tab) {
       case NOTIFICATION_TABS.ALL.index:
@@ -139,6 +128,12 @@ export default function NotificationPageNotificationPage() {
   useEffect(() => {
     fetchNotifications();
   }, [fetchNotifications]);
+
+  useEffect(() => {
+    setTimeout(() => {
+      dispatch(readAllNotification());
+    }, 300);
+  }, []);
 
   useEffect(() => {
     let observer;
@@ -213,16 +208,6 @@ export default function NotificationPageNotificationPage() {
           ))}
         </Tabs>
       </AppBar>
-      <ButtonWrapper>
-        <Button
-          size="medium"
-          className={`read-all-notifications ${classes.readAllButton}`}
-          onClick={handleReadAllNotification}
-          color="primary"
-        >
-          모두 읽음
-        </Button>
-      </ButtonWrapper>
       <TabPanel
         value={tab}
         index={NOTIFICATION_TABS.ALL.index}

--- a/frontend/src/pages/NotificationPage.jsx
+++ b/frontend/src/pages/NotificationPage.jsx
@@ -17,6 +17,8 @@ import {
   appendResponseRequests
 } from '../modules/notification';
 
+const READ_ALL_NOTI_DELAY = 300;
+
 Tabs.displayName = 'Tabs';
 function TabPanel(props) {
   const { children, value, index, ...other } = props;
@@ -132,7 +134,7 @@ export default function NotificationPageNotificationPage() {
   useEffect(() => {
     setTimeout(() => {
       dispatch(readAllNotification());
-    }, 300);
+    }, READ_ALL_NOTI_DELAY);
   }, []);
 
   useEffect(() => {

--- a/frontend/src/pages/NotificationPage.jsx
+++ b/frontend/src/pages/NotificationPage.jsx
@@ -135,7 +135,7 @@ export default function NotificationPageNotificationPage() {
     setTimeout(() => {
       dispatch(readAllNotification());
     }, READ_ALL_NOTI_DELAY);
-  }, []);
+  }, [dispatch]);
 
   useEffect(() => {
     let observer;


### PR DESCRIPTION
## Issue Number: #2 

## Self Check List
- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
노티 창의 '모두 읽음' 버튼을 없애고, 노티 창 오픈 시 모든 노티를 읽음 처리하도록 작업하였습니다.

1. '모두 읽음' 버튼 제거하고, 마운트 시 모든 노티 읽음 처리하도록 작업
  L '노티 창(`NotificationDropdownList`)'과 '노티 전체보기 페이지(`NotificationPage`)' 에 존재하는 '모두 읽음' 버튼 제거 후 각각 마운트 시 300ms 후 모든 노티를 읽음 처리하도록 설정하였습니다.
  L 창을 열자마자 읽음 처리된 노티 목록의 색이 변하는 것이 부자연스럽다고 생각하여 300ms 의 딜레이를 주었습니다..! 

2. '노티 개별 읽음 처리' 와 관련된 코드 제거
  L 노티 창 오픈 시 모든 노티가 일괄적으로 읽음처리 되기 때문에, 노티를 클릭하여 개별적으로 읽음 처리하는 동작이 의미가 없어졌고 이에 따라 각각의 노티를 개별적으로 읽음 처리하는 API 호출 관련 코드를 프론트엔드에서 걷어내었습니다. 
  
![화면 기록 2022-11-20 오후 11 45 27](https://user-images.githubusercontent.com/43427306/202912269-2241bb69-7190-4684-bbdd-c5533565fcf1.gif)


## More Comments
프론트엔드 + 백엔드 작업이 될 것이라고 예상하고 시작하였으나 작업하다보니 프론트엔드 코드를 우선적으로 변경하게 되었습니다..🙂 
백엔드에서 노티 정보를 업데이트하는 API는 우선 남겨두었는데, 필요하지 않다고 판단되면 요 API 도 제거해보겠습니다 !