### PR TITLE
(#48) 댓글 작성 시 항상 새로운 노티를 생성하도록 수정

### DIFF
--- a/backend/adoorback/comment/models.py
+++ b/backend/adoorback/comment/models.py
@@ -81,18 +81,11 @@ def create_noti(instance, **kwargs):
         message = f'{actor_name} 회원님의 {origin_target_name}에 댓글을 남겼습니다: "{content_preview}"'
         redirect_url = f'/{origin.type.lower()}s/{origin.id}?anonymous={instance.is_anonymous}'
 
-    notification = Notification.objects.filter(actor=actor,
-                                               user=user,
-                                               origin_id=origin.id,
-                                               origin_type=get_generic_relation_type(origin.type))
-    if notification.count() > 0:  # same notification exists --> update
-        notification[0].save()
-    else:
-        Notification.objects.create(actor=actor,
-                                    user=user,
-                                    origin_id=origin.id,
-                                    origin_type=get_generic_relation_type(origin.type),
-                                    target_id=target.id,
-                                    target_type=get_comment_type(),
-                                    message=message,
-                                    redirect_url=redirect_url)
+    Notification.objects.create(actor=actor,
+                                user=user,
+                                origin_id=origin.id,
+                                origin_type=get_generic_relation_type(origin.type),
+                                target_id=target.id,
+                                target_type=get_comment_type(),
+                                message=message,
+                                redirect_url=redirect_url)


### PR DESCRIPTION
## Issue Number: #48 

## Self Check List
- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
댓글 작성 시, 같은 유저가 같은 게시물에 이미 댓글을 단 적이 있다면 기존 노티를 업데이트 하던 방식에서 항상 새로운 노티를 생성하는 방식으로 수정하였습니다. 
노티 메세지에 새로운 댓글 내용이 미리보기로 추가되면서, 같은 유저의 같은 게시물에 대한 댓글 노티이더라도 댓글의 내용에 따라 노티 메세지가 달라지기 때문에 기존 노티를 그대로 유지하고 새로운 노티를 생성하는 방식으로 논의 되었습니다. 자세한 논의 과정은 [여기에서](https://www.notion.so/jinsungoo/10-30-b83e08933c854ad68e982e32450b213e) 확인해주세요 !

수정 전
![before](https://user-images.githubusercontent.com/43427306/204075167-d26e3f13-31a6-4ba1-89ef-7a7b3cbfeafb.gif)

수정 후
![after](https://user-images.githubusercontent.com/43427306/204075175-1e8632a6-cad0-4362-ac99-503320ab4c34.gif)
