### PR TITLE
(#53 #93) 좋아요 취소 관련 API 수정

### DIFF
--- a/backend/adoorback/like/serializers.py
+++ b/backend/adoorback/like/serializers.py
@@ -19,7 +19,7 @@ class LikeSerializer(serializers.ModelSerializer):
         return {
             "id": user.id,
             "username": user.username,
-        } 
+        }
 
     def get_target_type(self, obj):
         return obj.target.type

--- a/backend/adoorback/like/views.py
+++ b/backend/adoorback/like/views.py
@@ -10,16 +10,20 @@ from adoorback.utils.content_types import get_generic_relation_type
 from adoorback.utils.validators import adoor_exception_handler
 
 
-class LikeList(generics.CreateAPIView):
+class LikeList(generics.ListCreateAPIView):
     """
     List all likes, or create a new like.
     """
     queryset = Like.objects.all()
     serializer_class = LikeSerializer
     permission_classes = [IsAuthenticated]
+    pagination_class = None
 
     def get_exception_handler(self):
         return adoor_exception_handler
+
+    def get_queryset(self):
+        return Like.objects.filter(user=self.request.user)
 
     @transaction.atomic
     def perform_create(self, serializer):


### PR DESCRIPTION
## Issue Number: #53 #93  

## Self Check List
- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
프론트엔드에서 다음과 같은 순서로 좋아요 취소를 처리하고 있는데, 이 중 GET api/likes 에서 405 Method Not Allowed 에러가 발생하여 좋아요를 취소할 수 없는 상태였습니다.

```javascript
// 사용자의 좋아요 목록 부르기
GET api/likes

// 사용자의 좋아요 목록 중, 사용자가 취소하려는 좋아요와 target_id, target_type이 같은 좋아요 찾기

// 찾은 좋아요의 id로 삭제 API 호출
DELETE api/likes/:likeId
```

따라서 `api/likes` 를 처리하는 `LikeList` view 를 수정하였습니다. 수정 사항과 이유는 다음과 같습니다.

1. POST 메소드만 허용하는 CreateAPIVIew 에서 GET, POST 메소드를 허용하는 ListCreateAPIView 로 변경
2. 페이지네이션 적용하지 않도록 수정
  L 페이지네이션 적용 시 한번에 15개의 좋아요 목록만 받아올 수 있으며, 응답의 `data` 가 아닌 `data.results` 에 좋아요 목록이 담기게 됨
3. 요청을 보낸 사용자의 좋아요만 반환하도록 수정

수정 후
![화면 기록 2022-11-26 오후 6 37 58](https://user-images.githubusercontent.com/43427306/204082303-1500ad48-7722-4744-9ca7-49f2ad975de2.gif)


## More comments
@GooJinSun 결과적으로 백엔드 코드만 수정하였지만, 진선님과 API 형태와 관련하여 논의를 했었어서 리뷰를 함께 요청드렸습니다. 
논의를 시작할 때에 제가 장고에 대한 이해가 부족하여 좋지 않은 형태를 제안드렸더라구요 ㅠ_ㅠ 혼란을 드려 죄송합니다 !!

장고 Restful API 에 대하여 찾아보니 원래 작성되었던 것과 같은 아래 방식이 보편적으로 사용되는 방식으로 보여 기존 방식을 유지하도록 에러를 수정하였는데요,
```javascript
GET api/likes // 좋아요 목록 불러오기 
POST api/likes + 생성할 좋아요 정보 payload // 좋아요 생성하기 
DELETE api/likes/:likeId // 좋아요 삭제하기
```

좋아요 목록 불러오기를 좋아요 취소 외에는 사용하지 않기 때문에 아래와 같은 방식도 가능한데, 장고에서 DELETE 메소드 처리시에는 path variable 로 primary key 를 보내주는 것이 보편적인 것 같긴 하더라구요..!
```javascript
POST api/likes + 생성할 좋아요 정보 payload // 좋아요 생성하기 
DELETE api/likes/:target_id/:target_type // 좋아요 삭제하기
```

DELETE 메소드에 payload 를 함께 보내는 방식도 시도해보았는데, 장고에서 지원을 하지 않는 것으로 보여서 위의 두 가지 방식 중에 프론트에서 선호하는 방식으로 진행하면 좋을 것 같습니다 ! 위의 두 가지가 아니더라도 선호하는 방식이 있으시면 편하게 말씀주세요 감사합니다 :)