### PR TITLE
(#44) [노티] FCM 앱서버 연동 / react에 1차 적용시켜보기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ node_modules
 /backend/adoorback/feed/algorithms/user_contents.csv
 /backend/adoorback/feed/algorithms/recommendations.csv
 /backend/adoorback/adoor_data_export.sql
+
+# firebase
+/backend/adoorback/adoorback/serviceAccountKey.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 /frontend/.pnp
 /frontend/.pnp.js
 /frontend/.env
+/frontend/public/firebase-messaging-sw.js
 
 # testing
 /frontend/coverage

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 node_modules
 /frontend/.pnp
 /frontend/.pnp.js
+/frontend/.env
 
 # testing
 /frontend/coverage

--- a/backend/adoorback/adoorback/settings/base.py
+++ b/backend/adoorback/adoorback/settings/base.py
@@ -16,6 +16,10 @@ import datetime
 import os.path
 from datetime import timedelta
 
+import firebase_admin
+from firebase_admin import credentials
+from firebase_admin import initialize_app
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -81,6 +85,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'import_export',
     'trackstats',
+    'fcm_django',
 ]
 
 SITE_ID = 1
@@ -199,3 +204,27 @@ EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_HOST_USER = 'adoor.team@gmail.com'
 EMAIL_HOST_PASSWORD = os.environ['EMAIL_HOST_PASSWORD']
 SERVER_EMAIL = 'adoor.team'
+
+# https://fcm-django.readthedocs.io/en/latest/
+FIREBASE_CREDENTIAL_PATH = os.path.join(BASE_DIR, 'serviceAccountKey.json')
+FIREBASE_CREDENTIAL = credentials.Certificate(FIREBASE_CREDENTIAL_PATH);
+FIREBASE_APP = initialize_app(FIREBASE_CREDENTIAL)
+FCM_DJANGO_SETTINGS = {
+  # an instance of firebase_admin.App to be used as default for all fcm-django requests
+  # default: None (the default Firebase app)
+  "DEFAULT_FIREBASE_APP": None,
+  # default: _('FCM Django')
+  "APP_VERBOSE_NAME": "[string for AppConfig's verbose_name]",
+  # true if you want to have only one active device per registered user at a time
+  # default: False
+  "ONE_DEVICE_PER_USER": False,
+  # devices to which notifications cannot be sent,
+  # are deleted upon receiving error response from FCM
+  # default: False
+  "DELETE_INACTIVE_DEVICES": False,
+  # Transform create of an existing Device (based on registration id) into
+          # an update. See the section
+  # "Update of device with duplicate registration ID" for more details.
+  # default: False
+  "UPDATE_ON_DUPLICATE_REG_ID": False,
+}

--- a/backend/adoorback/feed/views.py
+++ b/backend/adoorback/feed/views.py
@@ -17,6 +17,9 @@ import feed.serializers as fs
 from feed.algorithms.data_crawler import select_daily_questions
 from feed.models import Article, Response, Question, Post, ResponseRequest
 
+from firebase_admin.messaging import Message, Notification
+from fcm_django.models import FCMDevice
+
 User = get_user_model()
 
 
@@ -169,6 +172,22 @@ class QuestionList(generics.ListCreateAPIView):
         # cache.delete('friend-{}'.format(self.request.user.id))
         # cache.delete('anonymous')
         # cache.delete('questions')
+
+        # NOTE: fcm 동작 원리를 쉽게 이해하기 위한 테스트용 코드입니다
+        # registration_token에 브라우저에서 받은 등록키를 바꾸어 입력하면 테스트해 볼 수 있습니다
+        # 실제 구현 시에는, 적절한 상황에 적절한 유저의 registration token을 사용해 메시지를 생성해야 합니다
+        registration_token = 'faFoMpJdr13t0Gc4r8trou:APA91bGbNMFLLeCnt1GBix4eVc64-NhTIaLPyAL4Rynp2l11V2inLmcUwu7t1SdbyYWkVqpHH2KnPEHSHcQlDXxdgKEOJ5su9Oj15VsyA5e6nJ5P1ck1t4exkR3MSL7g8Tg-xTCdgy6H'
+        message = Message(
+          notification = Notification(
+            title = '새로운 질문이 생성되었습니다!',
+            body = self.request.data.get('content'),
+          )
+        )
+
+        try:
+          response = FCMDevice.objects.send_message(message, False, [registration_token])
+        except Exception as e:
+          print("error", e)
         serializer.save(author=self.request.user)
 
 

--- a/backend/adoorback/requirements.txt
+++ b/backend/adoorback/requirements.txt
@@ -43,6 +43,8 @@ docopt>=0.6.2
 environ>=1.0
 et-xmlfile>=1.0.1
 Faker>=4.14.0
+fcm-django==1.0.12
+firebase-admin==5.4.0
 Flask>=1.1.2
 Flask-BasicAuth>=0.2.0
 gevent>=20.9.0

--- a/frontend/firebase-messaging-sw.js
+++ b/frontend/firebase-messaging-sw.js
@@ -1,0 +1,38 @@
+/**
+ * 서비스 워커 설정 파일
+ * 웹앱에서 백그라운드 노티를 수신할 때 동작합니다
+ */
+
+/* eslint-disable no-undef */
+// Scripts for firebase and firebase messaging
+// 참고: 왜 importScripts를 사용하나요? - https://web.dev/es-modules-in-sw/
+importScripts(
+  'https://www.gstatic.com/firebasejs/9.0.0/firebase-app-compat.js'
+);
+importScripts(
+  'https://www.gstatic.com/firebasejs/9.0.0/firebase-messaging-compat.js'
+);
+
+// Initialize the Firebase app in the service worker by passing in
+// your app's Firebase config object.
+// https://firebase.google.com/docs/web/setup#config-object
+// eslint-disable-next-line no-unused-vars
+const firebaseApp = firebase.initializeApp({
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.REACT_APP_FIREBASE_APP_ID
+  // databaseURL: 'https://project-id.firebaseio.com',
+  // storageBucket: 'project-id.appspot.com',
+  // measurementId: 'G-measurement-id'
+});
+
+// Retrieve an instance of Firebase Messaging so that it can handle background messages.
+// Retrieve firebase messaging
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage((payload) => {
+  console.log('Received background message ', payload);
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "date-fns": "^2.16.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.5",
+    "firebase": "^9.10.0",
     "global": "^4.4.0",
     "history": "^5.0.0",
     "intersection-observer": "^0.11.0",
@@ -100,5 +101,5 @@
       "!src/apis/index.js"
     ]
   },
-  "proxy": "http://127.0.0.1:8000/"
+  "proxy": "http://localhost:8000/"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "babel-plugin-styled-components": "^1.11.1",
     "connected-react-router": "^6.5.2",
     "coveralls": "^3.1.0",
+    "cra-append-sw": "^2.7.0",
     "date-fns": "^2.16.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.5",
@@ -43,6 +44,8 @@
     "use-onclickoutside": "^0.3.1"
   },
   "scripts": {
+    "prestart": "cra-append-sw --mode dev --env ./.env ./firebase-messaging-sw.js",
+    "prebuild": "cra-append-sw --mode build --env ./.env ./firebase-messaging-sw.js",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -18,6 +18,7 @@
       "sizes": "512x512"
     }
   ],
+  "gcm_sender_id": "177182746356",
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#000000",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,6 +33,7 @@ import useLogOutIfRefreshTokenExpired from './hooks/auth/useLogOutIfRefreshToken
 import LostPassword from './pages/LostPassword';
 import ResetPassword from './pages/ResetPassword';
 import useAppLogin from './hooks/auth/useAppLogin';
+import { initializeFirebase } from './utils/initializeFirebase';
 
 axios.defaults.xsrfHeaderName = 'X-CSRFTOKEN';
 axios.defaults.xsrfCookieName = 'csrftoken';
@@ -63,6 +64,7 @@ const App = () => {
 
   useEffect(() => {
     initGA();
+    initializeFirebase();
   }, []);
 
   useEffect(() => {

--- a/frontend/src/utils/initializeFirebase.js
+++ b/frontend/src/utils/initializeFirebase.js
@@ -1,0 +1,79 @@
+import { initializeApp } from 'firebase/app';
+import { getMessaging, getToken, onMessage } from 'firebase/messaging';
+
+// Your web app's Firebase configuration
+const firebaseConfig = {
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.REACT_APP_FIREBASE_APP_ID
+};
+
+// Initialize Firebase
+export const initializeFirebase = () => {
+  const app = initializeApp(firebaseConfig);
+  const messaging = getMessaging(app);
+
+  requestPermission();
+  getFCMRegistrationToken(messaging);
+  addForegroundMessageEventListener(messaging);
+};
+
+const requestPermission = () => {
+  console.log('Request permission...');
+
+  Notification.requestPermission().then(async (permission) => {
+    if (permission === 'granted') {
+      console.log('Notification permission granted.');
+
+      getFCMRegistrationToken();
+    }
+  });
+};
+
+const getFCMRegistrationToken = (messaging) => {
+  // Get registration token. Initially this makes a network call, once retrieved
+  // subsequent calls to getToken will return from cache.
+  getToken(messaging, {
+    vapidKey: process.env.REACT_APP_FIREBASE_VAPID_KEY
+  })
+    .then((registrationToken) => {
+      if (registrationToken) {
+        console.log(
+          `%c테스트를 위해 다음의 등록키를 backend/adoorback/feed/views.py의 registration_token에 등록해보세요!: ${registrationToken}`,
+          'color: yellow'
+        );
+        // Send the token to your server and update the UI if necessary
+        // TODO: registration key를 유저별로 서버에 저장할 수 있도록, 서버에 전송해야 함
+      } else {
+        // Show permission request UI
+        console.log(
+          'No registration token available. Request permission to generate one.'
+        );
+      }
+    })
+    .catch((err) => {
+      console.log('An error occurred while retrieving token. ', err);
+    });
+};
+
+const addForegroundMessageEventListener = (messaging) => {
+  onMessage(messaging, (payload) => {
+    console.log('Received foreground message', payload);
+
+    // TODO: 노티의 내용 구성, 제목, 링크, 아이콘 등의 설정 필요
+    const {
+      notification: { title, body }
+    } = payload;
+
+    const noti = new Notification(`${title}: ${body}`);
+    noti.onclick = () => {
+      // TODO: 노티를 클릭했을 때 동작 정의 필요 e.g. URL 이동 등
+      console.log('onclick foreground noti');
+    };
+  });
+};
+
+export default requestPermission;


### PR DESCRIPTION
## Issue Number: #44
**FCM 관련 작업은 `fcm` 브랜치를 base로 작업해주시면 됩니다! @h-yes-oo 

## Self Check List
- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe): 환경 설정 관련

## What does this PR do?
- React app에 fcm 푸시 노티를 수신할 수 있는 기본 환경 세팅
  -  `firebase` 패키지 설치
  - Firebase app initialize(`initializeFirebase`)
    - github에 공유되면 안되는 key들을 `.env`에 설정해서 사용할 수 있도록 환경 세팅(with `cra-append-sw`)
      - 서비스 워커 파일은 CRA의 `.env` 변수들을 바로 사용할 수 없어, `cra-append-sw` 패키지를 활용해 서비스 워커 파일(`frontend/firebase-messaging-sw.js`)에 환경 변수를 오버라이딩해서 생성할 수 있도록(`frontend/public/firebase-messaging-sw.js`) 세팅했습니다(프론트 구동(`yarn start`), 프론트 빌드(`yarn build`) 시 생성됨
    - 브라우저에서 알림 권한 받기(`requestPermission`)
    - fcm 서버에 클라이언트를 등록할 수 있는 registration token 발급(`getFCMRegistrationToken`)
    - 다이버스 탭이 열려있을 때(=foreground) 푸시를 받을 수 있는 핸들러 추가(`addForegroundMessageEventListener`)
- 웹 브라우저에서 백그라운드 푸시노티를 받을 수 있도록 Firebase 서비스 워커 등록
  - 다이버스 탭이 닫혀있을 때도(=백그라운드) 푸시 노티를 받기 위해 서비스 워커를 사용합니다
  - 단, 서비스워커는 브라우저 기반으로 동작하기 때문에 브라우저가 켜져있지 않다면 푸시 노티가 오지 않습니다
  - 위 React app과 마찬가지로 fcm app을 initialize
  - 백그라운드 푸시를 받을 수 있는 핸들러 추가
- 장고 서버에 fcm backend에 노티를 생성하고 송신하는 기본 환경 세팅
  - [`fcm-django`](https://fcm-django.readthedocs.io/en/latest/) 설치, 기본 세팅(`base.py`)
    - dependency로 필요한 `fcm-admin`도 `requirements.txt`에 추가
  - '새로운 질문 만들기' 시 fcm backend에 푸시 노티 생성
    - 테스트 코드로 이후 수정 필요합니다


## 로컬에서 테스트하는 방법
```bash
// frontend 패키지 설치
$ cd fronend
$ yarn install

// backend 패키지 설치
$ pip install -r requirements.txt
```
- FCM 관련 환경 변수, 인증키 파일 생성: 파일은 [노션](https://www.notion.so/jinsungoo/FCM-3b0c03c576d04e83a7af81bbf015606a#afc83b48f20c48dfa111480f22a3392f)에서 확인가능합니다
  - (백) adoor/backend/adoorback/adoorback/serviceAccountKey.json
  - (프론트) adoor/frontend/.env
- 프론트/백 서버 구동
- 브라우저 노티 권한 허용
  - <img width="342" alt="image" src="https://user-images.githubusercontent.com/37523788/205492130-b48505fb-b238-474d-b5a7-a10291d88ef5.png">
- 테스트 계정 로그인
- 브라우저 콘솔에서 테스트를 위한 등록 키 복사(브라우저, 기기마다 다른 등록키가 생성됩니다)
<img width="1510" alt="image" src="https://user-images.githubusercontent.com/37523788/205492081-31ddac0c-b5f4-4609-b4d1-51790a637cb7.png">

- `backend/adoorback/feed/views.py`의 `registration_token`을 복사한 키로 대체
- 새로운 질문 만들기
- 백그라운드/포그라운드에서 노티가 오는 것을 확인
  - 포그라운드 푸시 노티
    - <img width="1512" alt="스크린샷 2022-12-04 오후 8 35 05" src="https://user-images.githubusercontent.com/37523788/205492194-0b230fcc-2671-4163-84eb-034d2e302913.png">
 
  - 백그라운드 푸시 노티
    - <img width="1512" alt="스크린샷 2022-12-04 오후 8 35 26" src="https://user-images.githubusercontent.com/37523788/205492197-64779658-d162-4e3b-92c8-acf0effc5210.png">

