### PR TITLE
(#123) 친구 요청, 수락 노티의 redirect_url 을 user_id 에서 username 으로 변경

### DIFF
--- a/backend/adoorback/account/models.py
+++ b/backend/adoorback/account/models.py
@@ -132,17 +132,17 @@ def create_friend_noti(created, instance, **kwargs):
         Notification.objects.create(user=requestee, actor=requester,
                                     origin=requester, target=instance,
                                     message=f'{requester.username}님이 친구 요청을 보냈습니다.',
-                                    redirect_url=f'/users/{requester.id}')
+                                    redirect_url=f'/users/{requester.username}')
         return
     elif accepted:
         Notification.objects.create(user=requestee, actor=requester,
                                     origin=requester, target=requester,
                                     message=f'{requester.username}님과 친구가 되었습니다.',
-                                    redirect_url=f'/users/{requester.id}')
+                                    redirect_url=f'/users/{requester.username}')
         Notification.objects.create(user=requester, actor=requestee,
                                     origin=requestee, target=requestee,
                                     message=f'{requestee.username}님과 친구가 되었습니다.',
-                                    redirect_url=f'/users/{requestee.id}')
+                                    redirect_url=f'/users/{requestee.username}')
         # add friendship
         requester.friends.add(requestee)
 

--- a/backend/adoorback/account/tests.py
+++ b/backend/adoorback/account/tests.py
@@ -431,7 +431,7 @@ class FriendshipNotisAPITestCase(APITestCase):
             self.assertEqual(notification.user_id, current_user.id)
             self.assertEqual(notification.is_read, False)
             self.assertEqual(notification.is_visible, True)
-            self.assertEqual(notification.redirect_url, f'/users/{friend_user.id}')
+            self.assertEqual(notification.redirect_url, f'/users/{friend_user.username}')
 
         # PATCH (reject) FriendRequest (current_user -> friend_user)
         with self.login(username=current_user.username, password='password'):


### PR DESCRIPTION
## What does this PR do?

친구 요청 및 수락 노티의 redirect url 이 username 이 아닌 user id 로 되어 있어 친구의 페이지에 접근할 수 없는 문제가 있어 이를 수정하였습니다.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code Style Update (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Other (please describe):

## Further comments

@GooJinSun @ssm0318 버그 발견 및 제보 감사합니다~! 수정 후 친구 요청 및 수락 노티로 친구의 페이지에 정상적으로 접근 가능한 것을 확인하였습니다.