### PR TITLE
(#131) FCM 백엔드 적용

### DIFF
--- a/backend/adoorback/adoorback/settings/base.py
+++ b/backend/adoorback/adoorback/settings/base.py
@@ -226,5 +226,5 @@ FCM_DJANGO_SETTINGS = {
           # an update. See the section
   # "Update of device with duplicate registration ID" for more details.
   # default: False
-  "UPDATE_ON_DUPLICATE_REG_ID": False,
+  "UPDATE_ON_DUPLICATE_REG_ID": True,
 }

--- a/backend/adoorback/adoorback/urls.py
+++ b/backend/adoorback/adoorback/urls.py
@@ -18,6 +18,8 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import include, path
 
+from fcm_django.api.rest_framework import FCMDeviceAuthorizedViewSet
+
 
 urlpatterns = [
     path('api/content_reports/', include('content_report.urls')),
@@ -30,5 +32,6 @@ urlpatterns = [
     path('api/admin/', include('admin_honeypot.urls', namespace='admin_honeypot')),
     path('api/secret/', admin.site.urls),
     path('api/user/', include('rest_framework.urls', namespace='rest_framework')),
+    path('api/devices/', FCMDeviceAuthorizedViewSet.as_view({'post': 'create'}), name='create_fcm_device'),
 ]
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/backend/adoorback/feed/views.py
+++ b/backend/adoorback/feed/views.py
@@ -17,9 +17,6 @@ import feed.serializers as fs
 from feed.algorithms.data_crawler import select_daily_questions
 from feed.models import Article, Response, Question, Post, ResponseRequest
 
-from firebase_admin.messaging import Message, Notification
-from fcm_django.models import FCMDevice
-
 User = get_user_model()
 
 
@@ -172,22 +169,6 @@ class QuestionList(generics.ListCreateAPIView):
         # cache.delete('friend-{}'.format(self.request.user.id))
         # cache.delete('anonymous')
         # cache.delete('questions')
-
-        # NOTE: fcm 동작 원리를 쉽게 이해하기 위한 테스트용 코드입니다
-        # registration_token에 브라우저에서 받은 등록키를 바꾸어 입력하면 테스트해 볼 수 있습니다
-        # 실제 구현 시에는, 적절한 상황에 적절한 유저의 registration token을 사용해 메시지를 생성해야 합니다
-        registration_token = 'faFoMpJdr13t0Gc4r8trou:APA91bGbNMFLLeCnt1GBix4eVc64-NhTIaLPyAL4Rynp2l11V2inLmcUwu7t1SdbyYWkVqpHH2KnPEHSHcQlDXxdgKEOJ5su9Oj15VsyA5e6nJ5P1ck1t4exkR3MSL7g8Tg-xTCdgy6H'
-        message = Message(
-          notification = Notification(
-            title = '새로운 질문이 생성되었습니다!',
-            body = self.request.data.get('content'),
-          )
-        )
-
-        try:
-          response = FCMDevice.objects.send_message(message, False, [registration_token])
-        except Exception as e:
-          print("error", e)
         serializer.save(author=self.request.user)
 
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,7 +33,7 @@ import useLogOutIfRefreshTokenExpired from './hooks/auth/useLogOutIfRefreshToken
 import LostPassword from './pages/LostPassword';
 import ResetPassword from './pages/ResetPassword';
 import useAppLogin from './hooks/auth/useAppLogin';
-import { initializeFirebase } from './utils/initializeFirebase';
+import { initializeFirebase } from './utils/firebaseHelpers';
 
 axios.defaults.xsrfHeaderName = 'X-CSRFTOKEN';
 axios.defaults.xsrfCookieName = 'csrftoken';

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -64,8 +64,13 @@ const App = () => {
 
   useEffect(() => {
     initGA();
-    initializeFirebase();
   }, []);
+
+  useEffect(() => {
+    if (currentUser) {
+      initializeFirebase();
+    }
+  }, [currentUser]);
 
   useEffect(() => {
     if (currentUser) {

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -20,6 +20,7 @@ import { logout } from '../modules/user';
 import { fetchSearchResults } from '../modules/search';
 import MobileDrawer from './posts/MobileDrawer';
 import MobileFooter from './MobileFooter';
+import { deactivateFirebase } from '../utils/firebaseHelpers';
 
 const HelloUsername = styled.div`
   font-size: 16px;
@@ -152,6 +153,7 @@ const Header = ({ isMobile }) => {
   const handleClickLogout = () => {
     dispatch(logout());
     history.push('/login');
+    deactivateFirebase();
   };
 
   const toggleNotiOpen = () => {

--- a/frontend/src/utils/firebaseHelpers.js
+++ b/frontend/src/utils/firebaseHelpers.js
@@ -18,8 +18,16 @@ export const initializeFirebase = () => {
   const messaging = getMessaging(app);
 
   requestPermission();
-  getFCMRegistrationToken(messaging);
+  getFCMRegistrationToken(messaging, 'web', true);
   addForegroundMessageEventListener(messaging);
+};
+
+export const deactivateFirebase = () => {
+  const app = initializeApp(firebaseConfig);
+  const messaging = getMessaging(app);
+
+  requestPermission();
+  getFCMRegistrationToken(messaging, 'web', false);
 };
 
 const requestPermission = () => {
@@ -34,7 +42,7 @@ const requestPermission = () => {
   });
 };
 
-const getFCMRegistrationToken = (messaging) => {
+const getFCMRegistrationToken = (messaging, type = 'web', active = true) => {
   // Get registration token. Initially this makes a network call, once retrieved
   // subsequent calls to getToken will return from cache.
   if (!messaging) {
@@ -52,8 +60,9 @@ const getFCMRegistrationToken = (messaging) => {
         );
         // Send the token to your server and update the UI if necessary
         axios.post('/devices/', {
-          type: 'web',
-          registration_id: registrationToken
+          type,
+          registration_id: registrationToken,
+          active
         });
       } else {
         // Show permission request UI

--- a/frontend/src/utils/initializeFirebase.js
+++ b/frontend/src/utils/initializeFirebase.js
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getMessaging, getToken, onMessage } from 'firebase/messaging';
+import axios from '../apis';
 
 // Your web app's Firebase configuration
 const firebaseConfig = {
@@ -36,6 +37,10 @@ const requestPermission = () => {
 const getFCMRegistrationToken = (messaging) => {
   // Get registration token. Initially this makes a network call, once retrieved
   // subsequent calls to getToken will return from cache.
+  if (!messaging) {
+    return;
+  }
+
   getToken(messaging, {
     vapidKey: process.env.REACT_APP_FIREBASE_VAPID_KEY
   })
@@ -46,7 +51,10 @@ const getFCMRegistrationToken = (messaging) => {
           'color: yellow'
         );
         // Send the token to your server and update the UI if necessary
-        // TODO: registration key를 유저별로 서버에 저장할 수 있도록, 서버에 전송해야 함
+        axios.post('/devices/', {
+          type: 'web',
+          registration_id: registrationToken
+        });
       } else {
         // Show permission request UI
         console.log(
@@ -65,13 +73,14 @@ const addForegroundMessageEventListener = (messaging) => {
 
     // TODO: 노티의 내용 구성, 제목, 링크, 아이콘 등의 설정 필요
     const {
-      notification: { title, body }
+      notification: { title, body },
+      data: { url }
     } = payload;
 
-    const noti = new Notification(`${title}: ${body}`);
+    const noti = new Notification(title, { body });
     noti.onclick = () => {
       // TODO: 노티를 클릭했을 때 동작 정의 필요 e.g. URL 이동 등
-      console.log('onclick foreground noti');
+      console.log(url);
     };
   });
 };


### PR DESCRIPTION
---
title: "(#131) FCM 백엔드 적용 "
---

## Issue Number: #131

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
FCM 알림을 보내기 위한 백엔드 작업입니다.

1. registration token 저장
    - 유저가 로그인하면 프론트엔드에서 서버로 registration token 을 보내도록 구현하였습니다.
    - 백엔드에서는 받은 registration token 을 유저 정보와 함께 데이터베이스에 저장하도록 `FCMDeviceAuthorizedViewSet` 을 사용하였습니다.

2. 새로운 노티가 생성될 때마다 FCM 알림 보내기
    - Notification 모델의 인스턴스가 새로 생성되면 노티의 대상이 되는 유저의 디바이스로 FCM 알림을 보내도록 구현하였습니다.

3. 토큰 비활성화 하기
    - 로그아웃을 하면 저장된 토큰의 activate 필드를 False 로 설정하여 더이상 알림을 받지 못하도록 구현하였습니다.
    - 만약 로그아웃을 하지 않은 채로 다이버스 웹 사이트에서 나가면 계속해서 알림을 받게 되는데요, 이 부분에 대하여 기획적으로 논의가 필요할 것 같습니다.

## Preview Image
![화면 기록 2022-12-12 오전 12 00 38](https://user-images.githubusercontent.com/43427306/206911458-eefa2f13-c318-4d25-9f06-d69ed832106e.gif)

## Further comments
