### PR TITLE
(#122) [노티] 노티 모달 스크롤이 느리거나 작동을 안 할 때가 있음

### DIFF
--- a/frontend/src/components/_common/header/Header.jsx
+++ b/frontend/src/components/_common/header/Header.jsx
@@ -272,10 +272,7 @@ const Header = ({ isMobile }) => {
       </div>
       <div ref={notiDropDownRef}>
         {isNotiOpen && (
-          <NotificationDropdownList
-            notifications={notifications}
-            setIsNotiOpen={setIsNotiOpen}
-          />
+          <NotificationDropdownList setIsNotiOpen={setIsNotiOpen} />
         )}
       </div>
       <div ref={searchRef}>{isSearchOpen && <SearchDropdownList />}</div>

--- a/frontend/src/components/_common/header/notification-dropdown-list/NotificationDropdownList.jsx
+++ b/frontend/src/components/_common/header/notification-dropdown-list/NotificationDropdownList.jsx
@@ -3,19 +3,39 @@ import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import List from '@material-ui/core/List';
 import { useHistory } from 'react-router';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
-import { readAllNotification } from '@modules/notification';
+import {
+  readAllNotification,
+  appendNotifications,
+  getNotifications
+} from '@modules/notification';
 import NotificationItem from '@common-components/notification-item/NotificationItem';
+import useInfiniteScroll from '@hooks/useInfiniteScroll';
 import { useStyles, ButtonWrapper } from './NotificationDropdownList.styles';
 
 const READ_ALL_NOTI_DELAY = 300;
 
-const NotificationDropdownList = ({ notifications, setIsNotiOpen }) => {
+const NotificationDropdownList = ({ setIsNotiOpen }) => {
   const classes = useStyles();
+
   const history = useHistory();
   const dispatch = useDispatch();
+
+  const notifications = useSelector(
+    (state) => state.notiReducer.receivedNotifications
+  );
+
+  const onIntersect = () => {
+    if (notifications.length >= 90) return;
+    dispatch(appendNotifications());
+  };
+  const setTarget = useInfiniteScroll(onIntersect);
+
+  useEffect(() => {
+    dispatch(getNotifications());
+  }, [dispatch]);
 
   const notificationList = notifications?.map((noti) => (
     <NotificationItem
@@ -56,6 +76,7 @@ const NotificationDropdownList = ({ notifications, setIsNotiOpen }) => {
       ) : (
         <CardContent className={classes.notificationDropdownContent}>
           <List>{notificationList}</List>
+          <div ref={setTarget} />
         </CardContent>
       )}
     </Card>

--- a/frontend/src/hooks/useInfiniteScroll.jsx
+++ b/frontend/src/hooks/useInfiniteScroll.jsx
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const useInfiniteScroll = (onIntersectCallback) => {
+  const [target, setTarget] = useState();
+
+  const onIntersect = useCallback(
+    ([entry]) => {
+      if (entry.isIntersecting) {
+        onIntersectCallback();
+      }
+    },
+    [onIntersectCallback]
+  );
+
+  useEffect(() => {
+    let observer;
+    if (target) {
+      observer = new IntersectionObserver(onIntersect, { threshold: 1 });
+      observer.observe(target);
+    }
+    return () => observer && observer.disconnect();
+  }, [target, onIntersect]);
+
+  return setTarget;
+};
+
+export default useInfiniteScroll;

--- a/frontend/src/modules/notification/index.js
+++ b/frontend/src/modules/notification/index.js
@@ -204,7 +204,6 @@ export default function notiReducer(state, action) {
     return initialState;
   }
   switch (action.type) {
-    case READ_ALL_NOTIFICATIONS_SUCCESS:
     case GET_NOTIFICATIONS_SUCCESS:
       return {
         ...state,


### PR DESCRIPTION
## Issue Number: #122

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 노티 드랍다운 리스트를 15개마다 페이지네이션 + 최대 90개까지만 불러오도록 수정
- 현재 무한 스크롤이 가능한 것처럼 보이는 이유는 노티 드랍다운시 `readAllNotifications`에서 api 응답값으로 받는 전체 노티 목록을 `notiReducer.notifications`에 저장해서였네요:)
