### PR TITLE
(#168 #169) [친구 리스트 위젯] 친구 페이지 이동 버튼이 눌리지 않음

### DIFF
--- a/frontend/src/components/_common/friend-item/FriendItem.jsx
+++ b/frontend/src/components/_common/friend-item/FriendItem.jsx
@@ -20,7 +20,7 @@ const FriendItem = ({
 
   const onClickItem = () => {
     history.push(`/users/${username}`);
-    if (onClickCallback) onClickCallback();
+    onClickCallback?.();
   };
 
   return (

--- a/frontend/src/components/_common/friend-item/FriendItem.jsx
+++ b/frontend/src/components/_common/friend-item/FriendItem.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ListItemText from '@material-ui/core/ListItemText';
 import FaceIcon from '@material-ui/icons/Face';
 import FriendStatusButtons from '@common-components/friend-status-buttons/FriendStatusButtons';
+import { useHistory } from 'react-router';
 import { useStyles, FriendItemWrapper, FriendLink } from './FriendItem.styles';
 
 const FriendItem = ({
@@ -11,10 +12,16 @@ const FriendItem = ({
   isFriend,
   hasSentRequest,
   isPending,
-  onClickItem
+  onClickCallback
 }) => {
   const classes = useStyles();
   const { username } = friendObj;
+  const history = useHistory();
+
+  const onClickItem = () => {
+    history.push(`/users/${username}`);
+    if (onClickCallback) onClickCallback();
+  };
 
   return (
     <FriendItemWrapper onClick={onClickItem}>

--- a/frontend/src/components/_common/search-dropdown-list/SearchDropdownList.jsx
+++ b/frontend/src/components/_common/search-dropdown-list/SearchDropdownList.jsx
@@ -2,20 +2,17 @@ import React from 'react';
 import CardContent from '@material-ui/core/CardContent';
 import { useSelector } from 'react-redux';
 import FriendItem from '@common-components/friend-item/FriendItem';
-import { useHistory } from 'react-router';
 import { useStyles, SearchCard } from './SearchDropdownList.styles';
 
 const SearchDropdownList = ({ setIsSearchOpen }) => {
   const classes = useStyles();
   const results =
     useSelector((state) => state.searchReducer.searchObj.results) || [];
-  const history = useHistory();
 
   if (results.length === 0) return <></>;
 
-  const onClickItem = (user) => {
+  const closeSearchDropDown = () => {
     setIsSearchOpen(false);
-    history.push(`/users/${user.username}`);
   };
 
   return (
@@ -32,7 +29,7 @@ const SearchDropdownList = ({ setIsSearchOpen }) => {
           <FriendItem
             key={user.id}
             friendObj={user}
-            onClickItem={() => onClickItem(user)}
+            onClickCallback={closeSearchDropDown}
           />
         ))}
       </CardContent>


### PR DESCRIPTION
---
title: "(#168) (#169) [친구 리스트 위젯] 친구 페이지 이동 버튼이 눌리지 않음"
---

## Issue Number: #168 #169

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?

친구 관련 FriendItem을 클릭했을 때의 동작을 이전 작업에서 밖에서 처리하도록 뺀 이력이 있는데, 그것 때문에 아예 click시 동작을 하지 않았던 것 같습니다! 따라서 onClickItem을 FriendItem의 안에서 실행하고, 단 클릭시 callback이 필요하면 `onClickCallback` 넣어주는 식으로 해결했습니다! 

## Preview Image

## Further comments

#169 도 같은 FriendItem의 컴포넌트를 사용하고 있어서 발생한 문제고, 같이 해결되었습니다!