### PR TITLE
(#6) 비밀댓글 노출 오류 해결

### DIFF
--- a/backend/adoorback/comment/serializers.py
+++ b/backend/adoorback/comment/serializers.py
@@ -43,7 +43,9 @@ class CommentFriendSerializer(CommentBaseSerializer):
 
     def get_replies(self, obj):
         current_user = self.context.get('request', None).user
-        if obj.target.type != 'Comment' and obj.target.author == current_user:
+        if obj.target.type == 'Comment':
+            replies = Comment.objects.none()
+        elif obj.target.author == current_user or obj.author == current_user:
             replies = obj.replies.order_by('id')
         else:
             replies = obj.replies.filter(is_anonymous=False, is_private=False) | \


### PR DESCRIPTION
---
title: "(#6) 비밀댓글 노출 오류 해결"
---

## Issue Number: #6 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
댓글에 대한 대댓글을 serializers 에서 가져올 때, 

1) 해당 댓글의 유형이 '대댓글'인 경우 달린 대댓글이 존재하지 않는다.
2) 내 게시물에 달린 대댓글이거나 내 댓글에 달린 대댓글은 비밀로 작성된 것까지 모두 가져온다.
3) 1과 2에 해당하지 않는 경우 공개 (익명 x, 비밀 x) 대댓글과 내가 작성한 대댓글을 가져온다.

로 분기하도록 수정하였습니다.

따라서 기존에는 A의 게시물에 B가 단 비밀 댓글에 대한 대댓글을 B는 확인할 수 없었지만, 
수정한 후에는 B가 단 비밀 댓글에 대한 대댓글을 B가 모두 확인할 수 있게 됩니다.


## Preview Image
[수정 전]
![스크린샷 2023-01-28 오후 4 35 14](https://user-images.githubusercontent.com/43427306/215253501-8469629c-8e04-478a-84b5-01027a55bb64.png)
![스크린샷 2023-01-28 오후 4 35 09](https://user-images.githubusercontent.com/43427306/215253504-26f361f0-5be2-4463-b1c9-95e3cdc0e28c.png)


[수정 후]
![스크린샷 2023-01-28 오후 4 34 31](https://user-images.githubusercontent.com/43427306/215253509-333db494-50f6-4166-9ca8-cd1e7d86bb5f.png)
![스크린샷 2023-01-28 오후 4 34 23](https://user-images.githubusercontent.com/43427306/215253511-945fad63-3689-4be0-aa18-17864bd019a8.png)

## Further comments
