### PR TITLE
(#161) 받은 질문에 답한 후에도 받은 질문 노티 유지하도록 수정

### DIFF
--- a/backend/adoorback/feed/models.py
+++ b/backend/adoorback/feed/models.py
@@ -255,20 +255,6 @@ def create_request_answered_noti(instance, created, **kwargs):
 
 
 @transaction.atomic
-@receiver(post_save, sender=Response)
-def delete_response_request(instance, created, **kwargs):
-    if not created:
-        return
-
-    try:
-        response_requests = ResponseRequest.objects.filter(requestee_id=instance.author.id,
-                                                           question=instance.question)
-    except ResponseRequest.DoesNotExist:
-        return
-    response_requests.delete()
-
-
-@transaction.atomic
 @receiver(pre_delete, sender=Question)
 def protect_question_noti(instance, **kwargs):
     # response request에 대한 response 보냈을 때 발생하는 노티, like/comment로 발생하는 노티 모두 보호


### PR DESCRIPTION
---
title: "(#161) 받은 질문에 답한 후에도 받은 질문 노티 유지하도록 수정"
---

## Issue Number: #161 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
기존에는 받은 질문에 대한 포스트가 작성되면 해당 response_request 인스턴스가 삭제되고 이에 따라 노티가 함께 삭제되도록 구현되어 있어서 받은 질문에 답하면 해당 질문을 받았던 노티가 사라져 보이지 않았습니다.

받은 질문에 대한 노티를 유지하는 것으로 논의되어 response_request 인스턴스와 이에 따른 노티가 유지되도록 기존 로직을 제거하였습니다.

## Preview Image
![화면 기록 2023-01-28 오후 5 28 19](https://user-images.githubusercontent.com/43427306/215255765-17f2d246-160d-40b6-acd4-46467da530ea.gif)


## Further comments
