### PR TITLE
(#188) [노티 알림창] 프로필 사진이 때에 따라 길쭉하게 보여요

### DIFF
--- a/frontend/src/components/_common/user-profile-item/UserProfileItem.jsx
+++ b/frontend/src/components/_common/user-profile-item/UserProfileItem.jsx
@@ -14,6 +14,7 @@ const UserIcon = styled.span`
   overflow: hidden;
   border-radius: 50%;
   border: 1px solid #ddd;
+  flex-shrink: 0;
 `;
 
 const UserProfileItem = (props) => {


### PR DESCRIPTION
---
title: "(#188 ) [노티 알림창] 프로필 사진이 때에 따라 길쭉하게 보여요"
---

## Issue Number: #188 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 프로필 사진 노출 버그 해결

## Preview Image
![스크린샷 2023-02-26 오후 4 18 42](https://user-images.githubusercontent.com/42240753/221397633-b8fd96a2-6ff0-44e4-854a-99f9a9624b58.png)

## Further comments
