### PR TITLE
(#187) [Bug] 친구 요청이 없을 때, 노티 목록에 없다고 표시해주기

### DIFF
--- a/frontend/src/components/notification-page/NotificationPage.jsx
+++ b/frontend/src/components/notification-page/NotificationPage.jsx
@@ -15,6 +15,9 @@ import {
   appendResponseRequests
 } from '@modules/notification';
 import TabPanel, { a11yProps } from '@common-components/tab-panel/TabPanel';
+import Message from '@common-components/message/Message';
+import { CommonButton } from '@styles/buttons';
+import { useHistory } from 'react-router';
 import { useStyles } from './NotificationPage.styles';
 
 const READ_ALL_NOTI_DELAY = 300;
@@ -28,7 +31,7 @@ const NOTIFICATION_TABS = {
 
 export default function NotificationPageNotificationPage() {
   const dispatch = useDispatch();
-
+  const history = useHistory();
   const [target, setTarget] = useState(null);
   const [tab, setTab] = useState(NOTIFICATION_TABS.ALL.index);
 
@@ -85,6 +88,10 @@ export default function NotificationPageNotificationPage() {
     [dispatch, tab]
   );
 
+  const onClickGoQuestionFeed = () => {
+    history.push('/questions');
+  };
+
   useEffect(() => {
     fetchNotifications();
   }, [fetchNotifications]);
@@ -129,25 +136,58 @@ export default function NotificationPageNotificationPage() {
     );
   });
 
-  const friendRequestList = friendRequests.map((friendRequestNoti) => {
-    return (
-      <FriendItem
-        key={`friend-request-${friendRequestNoti?.id}`}
-        message={friendRequestNoti.message}
-        isPending
-        friendObj={friendRequestNoti?.actor_detail}
-        showFriendStatus
+  const friendRequestList =
+    friendRequests.length === 0 ? (
+      <Message
+        message="친구 요청이 없습니다."
+        messageDetail="친구를 검색해서 먼저 요청을 보내보세요!"
       />
+    ) : (
+      friendRequests.map((friendRequestNoti) => {
+        return (
+          <FriendItem
+            key={`friend-request-${friendRequestNoti?.id}`}
+            message={friendRequestNoti.message}
+            isPending
+            friendObj={friendRequestNoti?.actor_detail}
+            showFriendStatus
+          />
+        );
+      })
     );
-  });
 
-  const responseRequestList = responseRequests.map((responseRequest) => (
-    <NotificationItem
-      key={`response-request-${responseRequest?.id}`}
-      notiObj={responseRequest}
-      isNotificationPage
-    />
-  ));
+  const responseRequestList =
+    responseRequests.length === 0 ? (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center'
+        }}
+      >
+        <Message
+          message="받은 질문이 없습니다."
+          messageDetail="친구에게 먼저 질문을 보내보면 어떨까요? :)"
+          noBorder
+        />
+        <CommonButton
+          id="question-redirect-button"
+          margin="20px 0"
+          onClick={onClickGoQuestionFeed}
+          width="50%"
+        >
+          질문 피드 둘러보기
+        </CommonButton>
+      </div>
+    ) : (
+      responseRequests.map((responseRequest) => (
+        <NotificationItem
+          key={`response-request-${responseRequest?.id}`}
+          notiObj={responseRequest}
+          isNotificationPage
+        />
+      ))
+    );
 
   return (
     <div className={classes.root}>


### PR DESCRIPTION
---
title: "(#187) [Bug] 친구 요청이 없을 때, 노티 목록에 없다고 표시해주기"
---

## Issue Number: #187 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 노티 화면에서 만약 표시할 내용이 없다면, 문구를 추가해주기

## Preview Image

![스크린샷 2023-02-26 오후 4 36 31](https://user-images.githubusercontent.com/42240753/221398172-537b6f73-0ad2-423c-8a0e-5cf2e4d48769.png)
![스크린샷 2023-02-26 오후 4 37 06](https://user-images.githubusercontent.com/42240753/221398193-e79ccf1f-a3d0-4b2c-9285-f83a79a9ba9b.png)

## Further comments

문구는 제가 임의로 추가해봤습니다! 
나중에 친구가 없는 화면에서 앱 링크를 공유한다던지, 웹 링크를 공유한다던지의 (친구초대처럼..?) 행동을 하면 어떨까요?