### PR TITLE
(#137) 원 글의 작성자와 스레드 참여자에게 새로운 댓글에 대한 노티 보내주기

### DIFF
--- a/backend/adoorback/comment/models.py
+++ b/backend/adoorback/comment/models.py
@@ -7,6 +7,7 @@ from django.dispatch import receiver
 from django.db.models.signals import post_save
 
 from like.models import Like
+from account.models import User
 from notification.models import Notification
 from adoorback.models import AdoorModel
 from adoorback.utils.content_types import get_comment_type, get_generic_relation_type
@@ -53,44 +54,120 @@ class Comment(AdoorModel):
     @property
     def liked_user_ids(self):
         return self.comment_likes.values_list('user_id', flat=True)
+    
+    @property
+    def participants(self):
+        return self.replies.values_list('author_id', flat=True).distinct()
 
     class Meta:
         base_manager_name = 'objects'
 
 
-@transaction.atomic
 @receiver(post_save, sender=Comment)
 def create_noti(instance, **kwargs):
-    user = instance.target.author
+    origin_author = instance.target.author
     actor = instance.author
     origin = instance.target
     target = instance
 
-    if user == actor:  # do not create notification for comment author him/herself.
-        return
-    if actor.id in user.user_report_blocked_ids: # do not create notification from/for blocked user
-        return
     actor_name_ko = '익명의 사용자가' if instance.is_anonymous else f'{actor.username}님이'
     actor_name_en = 'An anonymous user' if instance.is_anonymous else f'{actor.username}'
     content_preview = wrap_content(instance.content)
 
-    if origin.type == 'Comment':  # if is_reply
-        message_ko = f'{actor_name_ko} 회원님의 댓글에 답글을 남겼습니다: "{content_preview}"'
-        message_en = f'{actor_name_en} has replied to your comment: "{content_preview}"'
+    # if is_reply
+    if origin.type == 'Comment':
         redirect_url = f'/{origin.target.type.lower()}s/{origin.target.id}?anonymous={instance.is_anonymous}'
-    else:  # if not reply
+        # send a notification to the author of the origin comment
+        if origin_author == actor:
+            pass
+        elif actor.id in origin_author.user_report_blocked_ids:
+            pass
+        else:
+            Notification.objects.create(actor=actor,
+                                        user=origin_author,
+                                        origin_id=origin.id,
+                                        origin_type=get_generic_relation_type(origin.type),
+                                        target_id=target.id,
+                                        target_type=get_comment_type(),
+                                        message_ko=f'{actor_name_ko} 회원님의 댓글에 답글을 남겼습니다: "{content_preview}"',
+                                        message_en=f'{actor_name_en} has replied to your comment: "{content_preview}"',
+                                        redirect_url=redirect_url)
+        # send a notification to the author of the feed where the origin comment commented
+        feed_author = origin.target.author
+        if feed_author == origin_author:
+            pass
+        elif feed_author == actor:
+            pass
+        elif actor.id in feed_author.user_report_blocked_ids:
+            pass
+        else:
+            feed_type_ko = '게시글' if origin.target.type == 'Article' else '답변'
+            feed_type_en = 'post' if origin.type == 'Article' else 'answer'
+            Notification.objects.create(actor=actor,
+                                        user=feed_author,
+                                        origin_id=origin.id,
+                                        origin_type=get_generic_relation_type(origin.type),
+                                        target_id=target.id,
+                                        target_type=get_comment_type(),
+                                        message_ko=f'회원님의 {feed_type_ko}에 달린 댓글에 새로운 답글이 달렸습니다: "{content_preview}"',
+                                        message_en=f'There\'s a new reply to the comment on your {feed_type_en}: "{content_preview}"',
+                                        redirect_url=redirect_url)
+        # send notifications to participants of the origin comment
+        for participant_id in origin.participants:
+            if participant_id == origin_author.id:
+                continue
+            if participant_id == feed_author.id:
+                continue
+            if participant_id == actor.id:
+                continue
+            participant = User.objects.get(id=participant_id)
+            if actor.id in participant.user_report_blocked_ids:
+                continue
+            Notification.objects.create(actor=actor,
+                                        user=participant,
+                                        origin_id=origin.id,
+                                        origin_type=get_generic_relation_type(origin.type),
+                                        target_id=target.id,
+                                        target_type=get_comment_type(),
+                                        message_ko=f'회원님이 답글을 남긴 댓글에 새로운 답글이 달렸습니다: "{content_preview}"',
+                                        message_en=f'There\'s a new reply in the comment thread where you left a reply: "{content_preview}"',
+                                        redirect_url=redirect_url)
+
+    # if not reply
+    else:
+        redirect_url = f'/{origin.type.lower()}s/{origin.id}?anonymous={instance.is_anonymous}'
+        # send a notification to the author of the origin feed
         origin_target_name_ko = '게시글' if origin.type == 'Article' else '답변'
         origin_target_name_en = 'post' if origin.type == 'Article' else 'answer'
-        message_ko = f'{actor_name_ko} 회원님의 {origin_target_name_ko}에 댓글을 남겼습니다: "{content_preview}"'
-        message_en = f'{actor_name_en} has commented on your {origin_target_name_en}: "{content_preview}"'
-        redirect_url = f'/{origin.type.lower()}s/{origin.id}?anonymous={instance.is_anonymous}'
-
-    Notification.objects.create(actor=actor,
-                                user=user,
-                                origin_id=origin.id,
-                                origin_type=get_generic_relation_type(origin.type),
-                                target_id=target.id,
-                                target_type=get_comment_type(),
-                                message_ko=message_ko,
-                                message_en=message_en,
-                                redirect_url=redirect_url)
+        if origin_author == actor:
+            pass
+        elif actor.id in origin_author.user_report_blocked_ids:
+            pass
+        else:
+            Notification.objects.create(actor=actor,
+                                        user=origin_author,
+                                        origin_id=origin.id,
+                                        origin_type=get_generic_relation_type(origin.type),
+                                        target_id=target.id,
+                                        target_type=get_comment_type(),
+                                        message_ko = f'{actor_name_ko} 회원님의 {origin_target_name_ko}에 댓글을 남겼습니다: "{content_preview}"',
+                                        message_en = f'{actor_name_en} has commented on your {origin_target_name_en}: "{content_preview}"',
+                                        redirect_url=redirect_url)
+        # send notifications to participants of the origin feed
+        for participant_id in origin.participants:
+            if participant_id == origin_author.id:
+                continue
+            if participant_id == actor.id:
+                continue
+            participant = User.objects.get(id=participant_id)
+            if actor.id in participant.user_report_blocked_ids:
+                continue
+            Notification.objects.create(actor=actor,
+                                        user=participant,
+                                        origin_id=origin.id,
+                                        origin_type=get_generic_relation_type(origin.type),
+                                        target_id=target.id,
+                                        target_type=get_comment_type(),
+                                        message_ko=f'회원님이 댓글을 남긴 {origin_target_name_ko}에 새로운 댓글이 달렸습니다: "{content_preview}"',
+                                        message_en=f'There\'s a new comment on the {origin_target_name_en} you commented on: "{content_preview}"',
+                                        redirect_url=redirect_url)

--- a/backend/adoorback/feed/models.py
+++ b/backend/adoorback/feed/models.py
@@ -38,6 +38,10 @@ class Article(AdoorModel):
     def liked_user_ids(self):
         return self.article_likes.values_list('user_id', flat=True)
 
+    @property
+    def participants(self):
+        return self.article_comments.values_list('author_id', flat=True).distinct()
+
     class Meta:
         indexes = [
             models.Index(fields=['-id']),
@@ -116,6 +120,10 @@ class Response(AdoorModel):
     @property
     def liked_user_ids(self):
         return self.response_likes.values_list('user_id', flat=True)
+
+    @property
+    def participants(self):
+        return self.response_comments.values_list('author_id', flat=True).distinct()
 
 
 class ResponseRequest(AdoorTimestampedModel):


### PR DESCRIPTION
---
title: "(#137) 원 글의 작성자와 스레드 참여자에게 새로운 댓글에 대한 노티 보내주기"
---

## Issue Number: #137 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
원 글의 작성자와 스레드 참여자에게 새로운 댓글에 대한 노티를 보내주도록 작업하였습니다.
1. `Article`, `Response`, `Comment` 모델에 각각 `participant` 라는 속성을 추가했습니다.
> `participant` 속성은 해당 인스턴스에 댓글을 단 유저 id의 배열을 의미합니다.
> 이후 노티를 보낼 때에 사용되며, 추후 슬랙과 같이 스레드 참여자를 표시하는 기능 등으로 확장될 수 있습니다.

2. 새로운 댓글이 댓글(`Comment`)에 대한 답글인 경우
> 댓글 작성자, 원 글 작성자, 댓글에 답글을 달았던 사람들에게 노티를 보냅니다.
> 
> 댓글 작성자에게는 `'A가 회원님의 댓글에 답글을 남겼습니다'`
> 원 글 작성자에게는 `'회원님의 게시글/답변에 달린 댓글에 새로운 답글이 달렸습니다'`
> 댓글에 답글을 달았던 사람들에게는 `'회원님이 답글을 남긴 댓글에 새로운 답글이 달렸습니다'`
> 라는 노티 메세지를 전송합니다.
> 
> 한 명의 유저가 위의 세가지 역할 중 두 가지 이상에 중복 해당된다면, `댓글 작성자 > 원 글 작성자 > 댓글에 답글을 달았던 사람` 의 우선순위에 따라 하나의 노티만 전송합니다.

3. 새로운 댓글이 게시글(`Article`) 또는 질문에 대한 답변(`Response`)에 대한 댓글인 경우
> 원 글 작성자, 원 글에 댓글을 단 모든 사람들에게 노티를 보냅니다.
> 
> 원 글 작성자에게는 `'A가 회원님의 게시글/답변에 댓글을 남겼습니다'`
> 원 글에 댓글을 달았던 사람들에게는 `'회원님이 댓글을 남긴 게시글/답변에 새로운 댓글이 달렸습니다'`
> 라는 노티 메세지를 전송합니다.
>
> 원 글 작성자가 원 글에 댓글을 달았던 경우에 원 글 작성자에게는 `'A가 회원님의 게시글/답변에 댓글을 남겼습니다'` 라는 노티만 전송합니다.

## Preview Image

## Further comments
