### PR TITLE
(#222) django-modeltranslation 패키지 버전 하드코딩

### DIFF
--- a/backend/adoorback/requirements.txt
+++ b/backend/adoorback/requirements.txt
@@ -30,7 +30,7 @@ django-cors-headers>=3.5.0
 django-cron>=0.5.1
 django-extensions>=3.0.9
 django-import-export>=2.4.0
-django-modeltranslation>=0.17.0
+django-modeltranslation==0.18.7
 django-mysql>=3.9.0
 django-polymorphic>=3.0.0
 django-queryset-csv>=1.1.0


### PR DESCRIPTION
---
title: "(# 222) django-modeltranslation 패키지 버전 하드코딩"
---

## Issue Number: #222

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- `django-modeltranslation` 패키지 업데이트에 따라 0.18.7에서 동작하는 기능이 0.18.9에서 동작하지 않는 문제
- requirements.txt에 `django-modeltranslation` 버전 설정을 `>=0.17.0`에서 `==0.18.7`로 변경
