### PR TITLE
(#226) 노티 모두 읽음 처리 대신 현재까지 받아온 노티 중 안 읽은 노티만 읽음 처리하도록 변경

### DIFF
--- a/backend/adoorback/notification/urls.py
+++ b/backend/adoorback/notification/urls.py
@@ -7,5 +7,5 @@ urlpatterns = [
     path('friend-requests/', views.FriendRequestNotiList.as_view(), name='friend-request-noti-list'),
     path('response-requests/', views.ResponseRequestNotiList.as_view(), name='response-request-noti-list'),
     path(r'unread/', views.notification_id, name='notification-id'),
-    path('<int:pk>/', views.NotificationDetail.as_view(), name='notification-update'),
+    path('read/', views.NotificationDetail.as_view(), name='notification-read'),
 ]

--- a/backend/adoorback/notification/views.py
+++ b/backend/adoorback/notification/views.py
@@ -14,7 +14,7 @@ from adoorback.utils.validators import adoor_exception_handler
 from adoorback.utils.content_types import get_friend_request_type, get_response_request_type
 
 
-class NotificationList(generics.ListAPIView, generics.UpdateAPIView):
+class NotificationList(generics.ListAPIView):
     serializer_class = NotificationSerializer
     permission_classes = [IsAuthenticated, IsOwnerOrReadOnly]
 
@@ -28,13 +28,6 @@ class NotificationList(generics.ListAPIView, generics.UpdateAPIView):
             translation.activate(lang)
 
         return Notification.objects.visible_only().filter(user=self.request.user)
-
-    @transaction.atomic
-    def update(self, request, *args, **kwargs):
-        self.get_queryset().filter(user=request.user).update(is_read=True)
-        queryset = Notification.objects.visible_only().filter(user=request.user)
-        serializer = NotificationSerializer(queryset, many=True, context={'request': request})
-        return Response(serializer.data)
 
 
 class FriendRequestNotiList(generics.ListAPIView):
@@ -83,19 +76,11 @@ class NotificationDetail(generics.UpdateAPIView):
     def get_exception_handler(self):
         return adoor_exception_handler
 
-    def get_object(self):
-        return Notification.objects.get(id=self.kwargs.get('pk'))
-
-    def update(self, request, *args, **kwargs):
+    def patch(self, request, *args, **kwargs):
         partial = kwargs.pop('partial', False)
-        instance = self.get_object()
-        serializer = self.get_serializer(instance, data=request.data, partial=partial)
-        serializer.is_valid(raise_exception=True)  # check `is_read` field
-        self.perform_update(serializer)
-        return Response(serializer.data)
+        ids = request.data.get('ids', [])
+        queryset = Notification.objects.filter(id__in=ids)
+        queryset.update(is_read=True)
+        serializer = self.get_serializer(queryset, many=True)
 
-    @transaction.atomic
-    def perform_update(self, serializer):
-        if self.get_object().user != self.request.user:
-            raise PermissionDenied("requester가 본인이 아닙니다...")
-        return serializer.save()
+        return Response(serializer.data)

--- a/frontend/src/components/_common/header/notification-dropdown-list/NotificationDropdownList.jsx
+++ b/frontend/src/components/_common/header/notification-dropdown-list/NotificationDropdownList.jsx
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import {
-  readAllNotification,
+  readNotifications,
   appendNotifications,
   getNotifications
 } from '@modules/notification';
@@ -16,7 +16,7 @@ import useInfiniteScroll from '@hooks/useInfiniteScroll';
 import { useTranslation } from 'react-i18next';
 import { useStyles, ButtonWrapper } from './NotificationDropdownList.styles';
 
-const READ_ALL_NOTI_DELAY = 300;
+const READ_ALL_NOTI_DELAY = 1000;
 
 const NotificationDropdownList = ({ setIsNotiOpen }) => {
   const [t] = useTranslation('translation', { keyPrefix: 'header' });
@@ -32,6 +32,9 @@ const NotificationDropdownList = ({ setIsNotiOpen }) => {
   const onIntersect = () => {
     if (notifications.length >= 90) return;
     dispatch(appendNotifications());
+    setTimeout(() => {
+      dispatch(readNotifications());
+    }, READ_ALL_NOTI_DELAY);
   };
   const setTarget = useInfiniteScroll(onIntersect);
 
@@ -49,7 +52,7 @@ const NotificationDropdownList = ({ setIsNotiOpen }) => {
 
   useEffect(() => {
     setTimeout(() => {
-      dispatch(readAllNotification());
+      dispatch(readNotifications());
     }, READ_ALL_NOTI_DELAY);
   }, [dispatch]);
 

--- a/frontend/src/components/notification-page/NotificationPage.jsx
+++ b/frontend/src/components/notification-page/NotificationPage.jsx
@@ -6,7 +6,7 @@ import Tab from '@material-ui/core/Tab';
 import FriendItem from '@common-components/friend-item/FriendItem';
 import NotificationItem from '@common-components/notification-item/NotificationItem';
 import {
-  readAllNotification,
+  readNotifications,
   appendNotifications,
   getNotifications,
   getResponseRequests,
@@ -22,7 +22,7 @@ import i18n from '@i18n';
 import { useTranslation } from 'react-i18next';
 import { useStyles } from './NotificationPage.styles';
 
-const READ_ALL_NOTI_DELAY = 300;
+const READ_ALL_NOTI_DELAY = 1000;
 
 // FIXME: ts 전환시 readonly로 대체
 const NOTIFICATION_TABS = {
@@ -84,6 +84,9 @@ export default function NotificationPageNotificationPage() {
         switch (tab) {
           case NOTIFICATION_TABS.ALL.index:
             dispatch(appendNotifications());
+            setTimeout(() => {
+              dispatch(readNotifications());
+            }, READ_ALL_NOTI_DELAY);
             break;
           case NOTIFICATION_TABS.FRIEND_REQUEST.index:
             dispatch(appendFriendRequests());
@@ -108,7 +111,7 @@ export default function NotificationPageNotificationPage() {
 
   useEffect(() => {
     setTimeout(() => {
-      dispatch(readAllNotification());
+      dispatch(readNotifications());
     }, READ_ALL_NOTI_DELAY);
   }, [dispatch]);
 

--- a/frontend/src/modules/notification/index.js
+++ b/frontend/src/modules/notification/index.js
@@ -51,12 +51,12 @@ export const APPEND_RESPONSE_REQUESTS_SUCCESS =
 export const APPEND_RESPONSE_REQUESTS_FAILURE =
   'RESPONSE_REQUESTS/APPEND_NOTIFICATION_FAILURE';
 
-export const READ_ALL_NOTIFICATIONS_REQUEST =
-  'notification/READ_ALL_NOTIFICATIONS_REQUEST';
-export const READ_ALL_NOTIFICATIONS_SUCCESS =
-  'notification/READ_ALL_NOTIFICATIONS_SUCCESS';
-export const READ_ALL_NOTIFICATIONS_FAILURE =
-  'notification/READ_ALL_NOTIFICATIONS_FAILURE';
+export const READ_NOTIFICATIONS_REQUEST =
+  'notification/READ_NOTIFICATIONS_REQUEST';
+export const READ_NOTIFICATIONS_SUCCESS =
+  'notification/READ_NOTIFICATIONS_SUCCESS';
+export const READ_NOTIFICATIONS_FAILURE =
+  'notification/READ_NOTIFICATIONS_FAILURE';
 
 export const getNotifications = () => async (dispatch) => {
   let res;
@@ -181,20 +181,36 @@ export const appendResponseRequests = () => async (dispatch, getState) => {
   });
 };
 
-export const readAllNotification = () => async (dispatch) => {
+export const readNotifications = () => async (dispatch, getState) => {
+  const { receivedNotifications } = getState().notiReducer;
+
+  if (!receivedNotifications) {
+    return;
+  }
+
+  const unreadNotifications = receivedNotifications
+    .filter((noti) => !noti.is_read)
+    .map((noti) => noti.id);
+
+  if (unreadNotifications.length === 0) {
+    return;
+  }
+
   let res;
-  dispatch({ type: 'notification/READ_ALL_NOTIFICATIONS_REQUEST' });
+  dispatch({ type: 'notification/READ_NOTIFICATIONS_REQUEST' });
   try {
-    res = await axios.put(`/notifications/`);
+    res = await axios.patch(`/notifications/read/`, {
+      ids: unreadNotifications
+    });
   } catch (error) {
     dispatch({
-      type: 'notification/READ_ALL_NOTIFICATIONS_FAILURE',
+      type: 'notification/READ_NOTIFICATIONS_FAILURE',
       error
     });
     return;
   }
   dispatch({
-    type: 'notification/READ_ALL_NOTIFICATIONS_SUCCESS',
+    type: 'notification/READ_NOTIFICATIONS_SUCCESS',
     res: res.data
   });
 };


### PR DESCRIPTION
## Issue Number: #226 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] main으로 머지되는 PR인 경우 [릴리즈 노트](https://github.com/GooJinSun/diivers/releases)를 작성해주세요

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
현재까지 받은 노티 개수가 많은 경우, 노티 창을 열어 첫 15개 노티를 받아온 이후 다음 15개 노티를 받아오기까지 시간이 오래걸리는 문제가 발생하였습니다. 
이는 노티창을 열었을 때 ‘모든 노티 읽음 처리하기’ 요청을 보내는데, 사용자가 가진 노티 개수가 많은 경우 해당 요청을 백엔드에서 처리하는 과정이 오래걸리기 때문에 그 다음 요청인 다음 노티 15개 가져오기 응답이 늦어지는 것으로 파악되었습니다.

<details>
<summary>문제 자세히 보기</summary>

![noti-speed-analysis](https://user-images.githubusercontent.com/43427306/226094991-db260f9f-28bf-4560-be57-c11f300f341d.png)

</details>

기존 백엔드의 '모든 노티 읽음 처리 API' 의 경우 사용자가 가진 모든 노티의 is_read 를 True 로 바꾸어주기 때문에 가진 노티 개수가 많은 경우 처리 속도가 매우 길어지기 때문에,
1. 프론트엔드에서 현재까지 받은 노티 중 읽음 처리가 되지 않은 노티의 아이디를 배열로 백엔드에 보내고, 
2. 백엔드에서는 요청으로 받은 배열의 id 의 노티만 읽음 처리하도록 수정하였습니다.

수정하면서 사용하지 않는 API 의 경우는 삭제하고, 백엔드 요청 url 을 보다 직관적으로 수정하였습니다.
