### PR TITLE
(#247) [Bug] 답변 작성 시 draft에 저장이 되고 익명피드에도 공개됨

### DIFF
--- a/frontend/src/components/_common/question-item/new-response/NewResponse.tsx
+++ b/frontend/src/components/_common/question-item/new-response/NewResponse.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState, useEffect } from 'react';
+import React, { ChangeEvent, useState, useEffect, useRef } from 'react';
 import ShareSettings from '@components/_common/share-settings/ShareSettings';
 import { TextareaAutosize } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
@@ -32,7 +32,10 @@ const NewResponse = ({ question, onSubmit }: NewResponseProps) => {
     }));
   };
 
+  const isSubmitted = useRef(false);
+
   const onSubmitHandler = () => {
+    isSubmitted.current = true;
     setNewPost((prev) => ({ ...prev, content: '' }));
     onSubmit?.();
   };
@@ -42,6 +45,7 @@ const NewResponse = ({ question, onSubmit }: NewResponseProps) => {
   const newPostRef = useDepsFree(newPost);
   useEffect(() => {
     return () => {
+      if (isSubmitted.current) return;
       if (!newPostRef.current.content.trim().length) return;
 
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/components/_common/share-settings/ShareSettings.tsx
+++ b/frontend/src/components/_common/share-settings/ShareSettings.tsx
@@ -57,7 +57,7 @@ export default function ShareSettings({
       );
       history.push(location.pathname.slice(0, -4));
     } else {
-      dispatch(
+      await dispatch(
         createPost({
           ...postObj,
           ...shareState


### PR DESCRIPTION
## Issue Number: #247

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
  - #255 와도 관련이 있는 이슈라 해당 branch를 base로 작업 진행했습니다!
- [x] base branch로부터 rebase를 했나요?
- [x] main으로 머지되는 PR인 경우 [릴리즈 노트](https://github.com/GooJinSun/diivers/releases)를 작성해주세요

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 답변 작성 시 draft에 저장이 되고 익명피드에도 공개되는 버그 수정
  - 답변 작성 시 draft에 저장되지 않도록 flag(`isSubmitted`) 추가(dec8612afedd9052d75d06dc605859758418d585)
  - 답변 작성 완료 후 `POST` 요청이 완료될때까지 await하고 피드를 refetch하도록 수정(d84abb68b508caadd96decfcf088eaef35af7225)

## Preview Image

## Further comments
