### PR TITLE
(#247) slow 3G 환경에서도 #247이 여전히 재현되는 버그 수정

### DIFF
--- a/frontend/src/components/_common/question-item/QuestionItem.jsx
+++ b/frontend/src/components/_common/question-item/QuestionItem.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link, useHistory, useLocation } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import FavoriteIcon from '@material-ui/icons/Favorite';
 import FavoriteBorderIcon from '@material-ui/icons/FavoriteBorder';
 import CreateIcon from '@material-ui/icons/Create';
@@ -27,8 +27,6 @@ import NewResponse from './new-response/NewResponse';
 export default function QuestionItem({ questionObj, onSubmit }) {
   const dispatch = useDispatch();
   const location = useLocation();
-  const history = useHistory();
-  const isQuestionList = location.pathname === '/questions';
   const isAnon =
     location?.pathname.includes('anonymous') ||
     location?.search?.includes('anonymous=True');
@@ -84,8 +82,6 @@ export default function QuestionItem({ questionObj, onSubmit }) {
   const onSubmitHandler = () => {
     onSubmit?.();
     setIsWriting(false);
-
-    if (isQuestionList) history.push('/home');
   };
 
   return (

--- a/frontend/src/components/_common/share-settings/ShareSettings.tsx
+++ b/frontend/src/components/_common/share-settings/ShareSettings.tsx
@@ -57,15 +57,19 @@ export default function ShareSettings({
       );
       history.push(location.pathname.slice(0, -4));
     } else {
+      resetContent?.();
+
       await dispatch(
         createPost({
           ...postObj,
           ...shareState
         })
       );
-      resetContent?.();
 
+      // FIXME: feed는 캐싱하면 의도치 않게 stale한 응답을 보여줄 수 있음
       refetchFriendPostList({ refetchPage: () => true });
+
+      if (location.pathname === '/questions') history.push('/home');
     }
 
     onSubmit?.();

--- a/frontend/src/components/friend-feed/FriendFeed.tsx
+++ b/frontend/src/components/friend-feed/FriendFeed.tsx
@@ -26,7 +26,6 @@ const FriendFeed = () => {
     fetchNextPage,
     isFetchingNextPage,
     isFetching,
-    isLoading,
     refetch: refetchFriendPostList
   } = useInfiniteFriendPostList();
 
@@ -71,7 +70,7 @@ const FriendFeed = () => {
         <PostList
           posts={friendPosts}
           isAppending={isFetchingNextPage}
-          isLoading={isLoading}
+          isLoading={isFetching}
         />
       )}
       <ScrollTopButton callback={refetchFriendPostList} />


### PR DESCRIPTION
## Issue Number: #247

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] main으로 머지되는 PR인 경우 [릴리즈 노트](https://github.com/GooJinSun/diivers/releases)를 작성해주세요

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- draft를 관리하는 `resetContent`를 `createPost`보다 먼저 실행해서 게시할 때도 draft로 저장되지 않도록 수정
- /home으로 redirect되는 로직을 비동기 `createPost`가 완료된 이후 되도록 해서, 이전 캐싱된 feed를 보여주지 않도록 수정
  - 점점 더 (자주 바뀔 수 있는 여지가 있는) feed는 캐싱하면 안된다는 생각이 강해지네요ㅠ.ㅠ
- refetch시에도 loading component를 보여줄 수 있도록 수정
> `isLoading` is only true if you have a hard loading state where you have no data. When you are refetching, you most certainly have data already, which is why the query stays in `success` state. This is the stale-while-revalidate principle react-query is built upon.
> 
> What you are most likely looking for is the `isFetching` flag, which will also be true for background updates. [참고 `isFetching` vs `isLoading`](https://github.com/TanStack/query/issues/2559)


## Preview Image

https://user-images.githubusercontent.com/37523788/229323120-c820c7c2-52c7-446c-86b8-d79c0821ba7a.mov



## Further comments
