### PR TITLE
(#246) [Bug] 게시글 수정 시 다른 게시글 내용이 열림 

### DIFF
--- a/frontend/src/components/post-edit/PostEdit.jsx
+++ b/frontend/src/components/post-edit/PostEdit.jsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router';
 import { getSelectedPost } from '@modules/post';
 import { PostListWrapper } from '@styles/wrappers';
 import PostEditItem from './post-edit-item/PostEditItem';
+import LoadingItem from '../post-detail/loading-item/LoadingItem';
 
 const PostEdit = () => {
   const { postType, id } = useParams();
@@ -15,12 +16,22 @@ const PostEdit = () => {
     dispatch(getSelectedPost(postType, id));
   }, [postType, id, dispatch]);
 
+  const isLoading =
+    useSelector(
+      (state) =>
+        state.loadingReducer[
+          `post/GET_SELECTED_${postType.toUpperCase().slice(0, -1)}`
+        ]
+    ) === 'REQUEST';
+
   return (
-    selectedPost && (
-      <PostListWrapper>
+    <PostListWrapper>
+      {isLoading || !selectedPost ? (
+        <LoadingItem />
+      ) : (
         <PostEditItem postObj={selectedPost} />
-      </PostListWrapper>
-    )
+      )}
+    </PostListWrapper>
   );
 };
 


### PR DESCRIPTION
## Issue Number: #246 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?
- [x] main으로 머지되는 PR인 경우 [릴리즈 노트](https://github.com/GooJinSun/diivers/releases)를 작성해주세요

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 게시글 수정시 다른 게시글 내용이 열리는 버그 수정
  - 게시글 수정 페이지에서 `postReducer.selectedPost`를 사용하는데, 이전에 수정하던 컨텐츠가 있는 경우 이전 컨텐츠를 노출하고 있었습니다. fetch하는 중에는 loading 컴포넌트를 노출할 수 있도록 버그 수정했습니다~

## Preview Image
- AS-IS(이전에 수정하던 컨텐츠가 노출됨)

https://user-images.githubusercontent.com/37523788/230705954-0977710a-d27c-4f4a-9278-2abccb892714.mov


- TO-BE(selectedPost에 저장된 게시글있더라도, 새로 fetch중에는 loading 컴포넌트 노출)

https://user-images.githubusercontent.com/37523788/230705959-15b6c015-25b9-49f5-ab9a-8cde393b1010.mov




## Further comments
