### PR TITLE
(#201) 노티 Permission UX 개선

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -61,7 +61,8 @@ const App = () => {
   useLoginWithToken();
   useLogOutIfRefreshTokenExpired();
 
-  const showPermissionPopup = useFcm();
+  const { notiPermissionStatus, requestPermissionHandler, onNotiPopupClose } =
+    useFcm();
 
   const currentUser = useSelector((state) => state.userReducer.currentUser);
 
@@ -165,7 +166,12 @@ const App = () => {
           </Switch>
         </FeedWrapper>
         {showWidget && <FriendListWidget />}
-        {showPermissionPopup && <NotiPermissionPopup />}
+        {notiPermissionStatus === 'default' && (
+          <NotiPermissionPopup
+            requestPermission={requestPermissionHandler}
+            onNotiPopupClose={onNotiPopupClose}
+          />
+        )}
       </MainWrapper>
     </MuiThemeProvider>
   );

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,7 @@ import Header from '@common-components/header/Header';
 import QuestionListWidget from '@common-components/question-list-widget/QuestionListWidget';
 import FriendListWidget from '@common-components/friend-list-widget/FriendListWidget';
 import PrivateRoute from '@common-components/private-route/PrivateRoute';
+import NotiPermissionPopup from '@common-components/noti-permission-popup/NotiPermissionPopup';
 import useLoginWithToken from '@hooks/auth/useLoginWithToken';
 import useLogOutIfRefreshTokenExpired from '@hooks/auth/useLogOutIfRefreshTokenExpired';
 import GlobalStyle from '@styles/globalStyle';
@@ -60,7 +61,7 @@ const App = () => {
   useLoginWithToken();
   useLogOutIfRefreshTokenExpired();
 
-  useFcm();
+  const showPermissionPopup = useFcm();
 
   const currentUser = useSelector((state) => state.userReducer.currentUser);
 
@@ -164,6 +165,7 @@ const App = () => {
           </Switch>
         </FeedWrapper>
         {showWidget && <FriendListWidget />}
+        {showPermissionPopup && <NotiPermissionPopup />}
       </MainWrapper>
     </MuiThemeProvider>
   );

--- a/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.styles.ts
+++ b/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.styles.ts
@@ -9,11 +9,32 @@ export const StyledNotiPermissionPopup = styled.div`
   bottom: 0;
   width: 100%;
   background-color: #f12c56;
+  padding: 8px;
+
+  div {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    button {
+      border: none;
+      background-color: transparent;
+      color: white;
+      font-size: 18px;
+      text-decoration: underline;
+    }
+
+    a {
+      display: block;
+      color: white;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
 
   button {
-    border: none;
-    background-color: transparent;
     color: white;
-    font-size: 18px;
   }
 `;

--- a/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.styles.ts
+++ b/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.styles.ts
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+export const StyledNotiPermissionPopup = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  background-color: #f12c56;
+
+  button {
+    border: none;
+    background-color: transparent;
+    color: white;
+    font-size: 18px;
+  }
+`;

--- a/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.styles.ts
+++ b/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.styles.ts
@@ -1,12 +1,15 @@
 import styled from 'styled-components';
 
-export const StyledNotiPermissionPopup = styled.div`
+interface StyledNotiPermissionPopupProps {
+  isMobile: boolean;
+}
+export const StyledNotiPermissionPopup = styled.div<StyledNotiPermissionPopupProps>`
   display: flex;
   align-items: center;
   justify-content: center;
   position: fixed;
   left: 0;
-  bottom: 0;
+  bottom: ${(props) => (props.isMobile ? '56px' : 0)};
   width: 100%;
   background-color: #f12c56;
   padding: 8px;
@@ -27,6 +30,7 @@ export const StyledNotiPermissionPopup = styled.div`
     a {
       display: block;
       color: white;
+      text-align: center;
 
       &:hover {
         text-decoration: underline;

--- a/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.tsx
+++ b/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.tsx
@@ -4,25 +4,32 @@ import { IconButton } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 import { StyledNotiPermissionPopup } from './NotiPermissionPopup.styles';
 
-const NotiPermissionPopup = () => {
+interface NotiPermissionPopupProps {
+  requestPermission: () => void;
+  onNotiPopupClose: () => void;
+}
+
+const NotiPermissionPopup = ({
+  requestPermission,
+  onNotiPopupClose
+}: NotiPermissionPopupProps) => {
   const [t] = useTranslation('translation', { keyPrefix: 'common_popup' });
-
-  const requestPermission = () => {
-    console.log('TODO');
-  };
-
-  const onClose = () => {
-    console.log('TODO');
-  };
 
   return (
     <StyledNotiPermissionPopup>
-      <button type="button" onClick={requestPermission}>
-        {t(
-          'allow_desktop_notification_to_receive_updates_from_friends_as_push_notifications'
-        )}
-      </button>
-      <IconButton onClick={onClose}>
+      <div>
+        <button type="button" onClick={requestPermission}>
+          {t(
+            'allow_notification_to_receive_updates_from_friends_as_push_notifications'
+          )}
+        </button>
+        {/* https://gist.github.com/rmcdongit/f66ff91e0dad78d4d6346a75ded4b751 */}
+        {/* TODO: 맥 이외의 환경 확인 필요 */}
+        <a href="x-apple.systempreferences:com.apple.preference.notifications">
+          {t('please_check_your_system_preferences')}
+        </a>
+      </div>
+      <IconButton onClick={onNotiPopupClose}>
         <CloseIcon />
       </IconButton>
     </StyledNotiPermissionPopup>

--- a/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.tsx
+++ b/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { IconButton } from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+import { StyledNotiPermissionPopup } from './NotiPermissionPopup.styles';
+
+const NotiPermissionPopup = () => {
+  const [t] = useTranslation('translation', { keyPrefix: 'common_popup' });
+
+  const requestPermission = () => {
+    console.log('TODO');
+  };
+
+  const onClose = () => {
+    console.log('TODO');
+  };
+
+  return (
+    <StyledNotiPermissionPopup>
+      <button type="button" onClick={requestPermission}>
+        {t(
+          'allow_desktop_notification_to_receive_updates_from_friends_as_push_notifications'
+        )}
+      </button>
+      <IconButton onClick={onClose}>
+        <CloseIcon />
+      </IconButton>
+    </StyledNotiPermissionPopup>
+  );
+};
+
+export default NotiPermissionPopup;

--- a/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.tsx
+++ b/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.tsx
@@ -6,14 +6,6 @@ import useWindowWidth from '@hooks/env/useWindowWidth';
 import { isMac } from '@utils/getUserAgent';
 import { StyledNotiPermissionPopup } from './NotiPermissionPopup.styles';
 
-declare global {
-  interface Window {
-    ReactNativeWebView: {
-      postMessage: any;
-    };
-  }
-}
-
 interface NotiPermissionPopupProps {
   requestPermission: () => void;
   onNotiPopupClose: () => void;
@@ -25,21 +17,12 @@ const NotiPermissionPopup = ({
 }: NotiPermissionPopupProps) => {
   const [t] = useTranslation('translation', { keyPrefix: 'common_popup' });
 
-  const onClickRequestPermission = () => {
-    if (window.ReactNativeWebView) {
-      window.ReactNativeWebView.postMessage('OPEN_SETTINGS');
-      return;
-    }
-
-    requestPermission();
-  };
-
   const { isMobile } = useWindowWidth();
 
   return (
     <StyledNotiPermissionPopup isMobile={isMobile}>
       <div>
-        <button type="button" onClick={onClickRequestPermission}>
+        <button type="button" onClick={requestPermission}>
           {t(
             'allow_notification_to_receive_updates_from_friends_as_push_notifications'
           )}

--- a/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.tsx
+++ b/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.tsx
@@ -5,6 +5,14 @@ import CloseIcon from '@material-ui/icons/Close';
 import useWindowWidth from '@hooks/env/useWindowWidth';
 import { StyledNotiPermissionPopup } from './NotiPermissionPopup.styles';
 
+declare global {
+  interface Window {
+    ReactNativeWebView: {
+      postMessage: any;
+    };
+  }
+}
+
 const isMac = (userAgent?: string) => {
   if (!userAgent) return false;
   return userAgent.indexOf('Mac') !== -1;
@@ -21,12 +29,21 @@ const NotiPermissionPopup = ({
 }: NotiPermissionPopupProps) => {
   const [t] = useTranslation('translation', { keyPrefix: 'common_popup' });
 
+  const onClickRequestPermission = () => {
+    if (window.ReactNativeWebView) {
+      window.ReactNativeWebView.postMessage('OPEN_SETTINGS');
+      return;
+    }
+
+    requestPermission();
+  };
+
   const { isMobile } = useWindowWidth();
 
   return (
     <StyledNotiPermissionPopup isMobile={isMobile}>
       <div>
-        <button type="button" onClick={requestPermission}>
+        <button type="button" onClick={onClickRequestPermission}>
           {t(
             'allow_notification_to_receive_updates_from_friends_as_push_notifications'
           )}

--- a/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.tsx
+++ b/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { IconButton } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
+import useWindowWidth from '@hooks/env/useWindowWidth';
 import { StyledNotiPermissionPopup } from './NotiPermissionPopup.styles';
+
+const isMac = (userAgent?: string) => {
+  if (!userAgent) return false;
+  return userAgent.indexOf('Mac') !== -1;
+};
 
 interface NotiPermissionPopupProps {
   requestPermission: () => void;
@@ -15,8 +21,10 @@ const NotiPermissionPopup = ({
 }: NotiPermissionPopupProps) => {
   const [t] = useTranslation('translation', { keyPrefix: 'common_popup' });
 
+  const { isMobile } = useWindowWidth();
+
   return (
-    <StyledNotiPermissionPopup>
+    <StyledNotiPermissionPopup isMobile={isMobile}>
       <div>
         <button type="button" onClick={requestPermission}>
           {t(
@@ -25,9 +33,11 @@ const NotiPermissionPopup = ({
         </button>
         {/* https://gist.github.com/rmcdongit/f66ff91e0dad78d4d6346a75ded4b751 */}
         {/* TODO: 맥 이외의 환경 확인 필요 */}
-        <a href="x-apple.systempreferences:com.apple.preference.notifications">
-          {t('please_check_your_system_preferences')}
-        </a>
+        {isMac(window?.navigator.userAgent) && (
+          <a href="x-apple.systempreferences:com.apple.preference.notifications">
+            {t('please_check_your_system_preferences')}
+          </a>
+        )}
       </div>
       <IconButton onClick={onNotiPopupClose}>
         <CloseIcon />

--- a/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.tsx
+++ b/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { IconButton } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 import useWindowWidth from '@hooks/env/useWindowWidth';
+import { isMac } from '@utils/getUserAgent';
 import { StyledNotiPermissionPopup } from './NotiPermissionPopup.styles';
 
 declare global {
@@ -12,11 +13,6 @@ declare global {
     };
   }
 }
-
-const isMac = (userAgent?: string) => {
-  if (!userAgent) return false;
-  return userAgent.indexOf('Mac') !== -1;
-};
 
 interface NotiPermissionPopupProps {
   requestPermission: () => void;

--- a/frontend/src/hooks/useFcm.jsx
+++ b/frontend/src/hooks/useFcm.jsx
@@ -16,24 +16,27 @@ const useFcm = () => {
   const dispatch = useDispatch();
   const history = useHistory();
 
-  const [showPermissionPopup, setShowPermissionPopup] = useState(false);
+  const [notiPermissionStatus, setNotiPermissionStatus] = useState(
+    Notification.permission
+  );
+
+  const requestPermissionHandler = async () => {
+    const permission = await requestPermission();
+    setNotiPermissionStatus(permission);
+  };
+
+  const onNotiPopupClose = () => setNotiPermissionStatus();
 
   useEffect(() => {
     if (!currentUser) return;
 
-    const initializeFirebase = async () => {
+    const initializeFcm = async () => {
       try {
         const app = initializeApp(firebaseConfig);
         const messaging = getMessaging(app);
 
-        const permission = await requestPermission();
+        if (notiPermissionStatus !== 'granted' || !app || !messaging) return;
 
-        if (!permission || !app || !messaging) return;
-
-        if (permission !== 'granted') {
-          setShowPermissionPopup(true);
-          return;
-        }
         const token = await getFCMRegistrationToken(messaging);
         addForegroundMessageEventListener(messaging, history.push);
 
@@ -43,10 +46,10 @@ const useFcm = () => {
       }
     };
 
-    initializeFirebase();
-  }, [currentUser, dispatch, history.push]);
+    initializeFcm();
+  }, [currentUser, dispatch, history.push, notiPermissionStatus]);
 
-  return showPermissionPopup;
+  return { notiPermissionStatus, requestPermissionHandler, onNotiPopupClose };
 };
 
 export default useFcm;

--- a/frontend/src/hooks/useFcm.jsx
+++ b/frontend/src/hooks/useFcm.jsx
@@ -1,6 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getMessaging } from 'firebase/messaging';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { setFcmToken } from '../modules/user';
@@ -16,6 +16,8 @@ const useFcm = () => {
   const dispatch = useDispatch();
   const history = useHistory();
 
+  const [showPermissionPopup, setShowPermissionPopup] = useState(false);
+
   useEffect(() => {
     if (!currentUser) return;
 
@@ -25,8 +27,13 @@ const useFcm = () => {
         const messaging = getMessaging(app);
 
         const permission = await requestPermission();
+
         if (!permission || !app || !messaging) return;
 
+        if (permission !== 'granted') {
+          setShowPermissionPopup(true);
+          return;
+        }
         const token = await getFCMRegistrationToken(messaging);
         addForegroundMessageEventListener(messaging, history.push);
 
@@ -38,6 +45,8 @@ const useFcm = () => {
 
     initializeFirebase();
   }, [currentUser, dispatch, history.push]);
+
+  return showPermissionPopup;
 };
 
 export default useFcm;

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -9,7 +9,8 @@
     "view_all_notifications": "View all notifications"
   }, 
   "common_popup": {
-    "allow_desktop_notification_to_receive_updates_from_friends_as_push_notifications": "Allow desktop notification to receive updates from friends as push notifications!"
+    "allow_notification_to_receive_updates_from_friends_as_push_notifications": "Allow notification to receive updates from friends as push notifications!",
+    "please_check_your_system_preferences": "If you don't get any notifications, please check the system preferences of your device."
   },
   "mobile": {
     "drawer": {

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -7,6 +7,9 @@
     "logout": "Logout",
     "login": "Login",
     "view_all_notifications": "View all notifications"
+  }, 
+  "common_popup": {
+    "allow_desktop_notification_to_receive_updates_from_friends_as_push_notifications": "Allow desktop notification to receive updates from friends as push notifications!"
   },
   "mobile": {
     "drawer": {

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -9,7 +9,8 @@
     "view_all_notifications": "알림 전체 보기"
   },
   "common_popup": {
-    "allow_desktop_notification_to_receive_updates_from_friends_as_push_notifications!": "데스크탑 알림 활성화 권한을 허용해 친구들의 새로운 소식을 푸시 알림으로 받아보세요!"
+    "allow_notification_to_receive_updates_from_friends_as_push_notifications": "알림을 허용해 친구들의 새로운 소식을 푸시 알림으로 받아보세요!",
+    "please_check_your_system_preferences": "알림이 오지 않는다면 시스템의 알림 설정을 확인해주세요."
   },
   "mobile": {
     "drawer": {

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -8,6 +8,9 @@
     "login": "로그인",
     "view_all_notifications": "알림 전체 보기"
   },
+  "common_popup": {
+    "allow_desktop_notification_to_receive_updates_from_friends_as_push_notifications!": "데스크탑 알림 활성화 권한을 허용해 친구들의 새로운 소식을 푸시 알림으로 받아보세요!"
+  },
   "mobile": {
     "drawer": {
       "friends": "친구",

--- a/frontend/src/utils/firebaseHelpers.js
+++ b/frontend/src/utils/firebaseHelpers.js
@@ -14,8 +14,7 @@ export const firebaseConfig = {
 export const requestPermission = async () => {
   try {
     const permission = await Notification.requestPermission();
-    if (permission === 'granted') return true;
-    return false;
+    return permission;
   } catch (e) {
     return false;
   }

--- a/frontend/src/utils/getUserAgent.ts
+++ b/frontend/src/utils/getUserAgent.ts
@@ -1,4 +1,4 @@
-export const isMac = (userAgent?: string) => {
+export const isMac = (userAgent = window?.navigator.userAgent) => {
   if (!userAgent) return false;
   return userAgent.indexOf('Mac') !== -1;
 };

--- a/frontend/src/utils/getUserAgent.ts
+++ b/frontend/src/utils/getUserAgent.ts
@@ -1,0 +1,4 @@
+export const isMac = (userAgent?: string) => {
+  if (!userAgent) return false;
+  return userAgent.indexOf('Mac') !== -1;
+};


### PR DESCRIPTION
## Issue Number: #201 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 노티 알림 설정을 돕는 Permission UX 추가
  - 버튼 클릭시 노티 알림 설정 요청
    - ![Apr-15-2023 14-08-28](https://user-images.githubusercontent.com/37523788/232184345-5ab79788-3c3f-4dc7-9a28-50d39ead70d7.gif)

  - (맥일 경우) 시스템 환경 설정 > 알림 센터 열기
    - ![Apr-15-2023 14-08-52](https://user-images.githubusercontent.com/37523788/232184350-c3a679d3-d044-4244-b26d-cc6a0b0b62ca.gif)
  - 웹뷰인 경우 `OPEN_SETTINGS` postMessage 전송 @koyrkr 앱쪽 작업 부탁드립니다!

## Preview Image
- 모바일, 다국어(한국어)
 - <img width="409" alt="스크린샷 2023-04-15 오후 2 11 23" src="https://user-images.githubusercontent.com/37523788/232184399-4b6b6270-2940-4a24-8575-53ba1782ffdd.png">

## Further comments
