### PR TITLE
[Bug] 컨텐츠 삭제 시 푸시 알림에 반영이 되지 않는 문제 해결

### DIFF
--- a/backend/adoorback/notification/models.py
+++ b/backend/adoorback/notification/models.py
@@ -97,8 +97,11 @@ def send_firebase_notification(created, instance, **kwargs):
         print("error while sending a firebase notification: ", e)
 
 
-@receiver(pre_delete, sender=Notification)
+@receiver(post_save, sender=Notification)
 def cancel_firebase_notification(sender, instance, **kwargs):
+    if not instance.deleted:
+        return
+
     message = Message(
         data = {
             'body' : '삭제된 알림입니다.',


### PR DESCRIPTION
## Issue Number: #280 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
이전에 컨텐츠 삭제 시 푸시 알림에 반영해주기 작업 (https://github.com/GooJinSun/diivers/pull/205) 을 진행하였는데, 배포가 되었음에도 프로덕션에서 해당 기능이 작동하지 않는 문제가 있습니다.

원인은 다음과 같이 파악하였습니다.
기존에 컨텐츠 삭제 시 pre_delete receiver 의해 푸시 알림을 수정하도록 구현하였는데, soft-delete 작업이 반영되어 배포되면서 이제는 컨텐츠를 삭제하면 pre_delete 이벤트가 아닌 post_save 이벤트가 발생하기 때문으로 추정됩니다.

따라서 컨텐츠 삭제를 pre_delete 가 아닌 post_save 리시버로 감지하도록 수정하였습니다.

## Preview Image


## Further comments
