### PR TITLE
(#269) 새로운 글 바로 반영이 안됨

### DIFF
--- a/frontend/src/components/friend-feed/FriendFeed.tsx
+++ b/frontend/src/components/friend-feed/FriendFeed.tsx
@@ -22,7 +22,7 @@ const FriendFeed = () => {
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
-    isFetching,
+    isLoading,
     refetch: refetchFriendPostList
   } = useInfiniteFriendPostList();
 
@@ -56,7 +56,7 @@ const FriendFeed = () => {
     <>
       <NewPost />
       <GoToDraftButton />
-      {friendPosts?.length === 0 && !isFetching ? (
+      {friendPosts?.length === 0 && !isLoading ? (
         <Message
           margin="16px 0"
           message={t('there_is_no_posts_to_display')}
@@ -67,7 +67,7 @@ const FriendFeed = () => {
         <PostList
           posts={friendPosts}
           isAppending={isFetchingNextPage}
-          isLoading={isFetching}
+          isLoading={isLoading}
         />
       )}
       <ScrollTopButton callback={refetchFriendPostList} />


### PR DESCRIPTION
## Issue Number: #269 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 새로운 글 바로 반영이 안되는 버그 수정 & 무한스크롤 버그 수정
- #263 에서 `isLoading` -> `isFetching`으로 수정한 부분 롤백
> `isLoading` is only true if you have a hard loading state where you have no data. When you are refetching, you most certainly have data already, which is why the query stays in `success` state. This is the stale-while-revalidate principle react-query is built upon.
> 
> What you are most likely looking for is the `isFetching` flag, which will also be true for background updates. [참고 `isFetching` vs `isLoading`](https://github.com/TanStack/query/issues/2559)

https://user-images.githubusercontent.com/37523788/232230744-c8d572ed-3b7d-48bf-bd15-ec4270823675.mov

대신 이제  refetch할 때 로딩 컴포넌트는 안보인다...!

## Preview Image

## Further comments
새로운 글 업데이트도, 무한스크롤도 잘 된다.. 되는데 왜 되는지 모른다...
`isFetching`을 넘겨줄 땐 data가 이전 캐시 데이터를 바라보고, `isLoading`으로 넘겨줄 땐 data가 새로  fetch한 데이터를 바라본다...
위 설명에 따르면 `isLoading`은 첫 로드 때만 true, `isFetching`은 cache된 데이터가 있든 없든 fetch할 때 true인데...
@koyrkr 지나님 https://github.com/GooJinSun/diivers/pull/173 여기서 `isLoading`, `IsFetching`을 구분해서 사용했던데 이유가 있었을까요?(제가 잘못이해하고 있는 부분이 있는 거 같아 질문드려요!)