### PR TITLE
(#285) [Bug] iOS (safari, chrome) Notification.permission 지원 안함 

### DIFF
--- a/frontend/src/hooks/useFcm.jsx
+++ b/frontend/src/hooks/useFcm.jsx
@@ -16,9 +16,7 @@ const useFcm = () => {
   const dispatch = useDispatch();
   const history = useHistory();
 
-  const [notiPermissionStatus, setNotiPermissionStatus] = useState(
-    Notification.permission
-  );
+  const [notiPermissionStatus, setNotiPermissionStatus] = useState(null);
 
   const requestPermissionHandler = async () => {
     const permission = await requestPermission();
@@ -34,6 +32,9 @@ const useFcm = () => {
       try {
         const app = initializeApp(firebaseConfig);
         const messaging = getMessaging(app);
+        await Notification.requestPermission().then((permission) =>
+          setNotiPermissionStatus(permission)
+        );
 
         if (notiPermissionStatus !== 'granted' || !app || !messaging) return;
 


### PR DESCRIPTION
## Issue Number: #285 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?

iOS 모바일 환경에서는 Notification.permission을 지원하지 않는다는 이야기가 있고, 
대신 Notification.requestpermission을 사용했습니다!

## Preview Image

## Further comments
