### PR TITLE
(#285) [Bug] iOS (safari, chrome) Notification.permission 지원 안함

### DIFF
--- a/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.tsx
+++ b/frontend/src/components/_common/noti-permission-popup/NotiPermissionPopup.tsx
@@ -29,7 +29,7 @@ const NotiPermissionPopup = ({
         </button>
         {/* https://gist.github.com/rmcdongit/f66ff91e0dad78d4d6346a75ded4b751 */}
         {/* TODO: 맥 이외의 환경 확인 필요 */}
-        {isMac(window?.navigator.userAgent) && (
+        {isMac() && (
           <a href="x-apple.systempreferences:com.apple.preference.notifications">
             {t('please_check_your_system_preferences')}
           </a>

--- a/frontend/src/utils/getUserAgent.ts
+++ b/frontend/src/utils/getUserAgent.ts
@@ -1,4 +1,20 @@
 export const isMac = (userAgent = window?.navigator.userAgent) => {
   if (!userAgent) return false;
-  return userAgent.indexOf('Mac') !== -1;
+  return /Mac/i.test(userAgent);
+};
+
+export const getMobileDeviceInfo = (
+  userAgent = window?.navigator.userAgent
+) => {
+  const isMobile = /Mobile/i.test(userAgent);
+  const isIOS = /iPhone|iPad|iPod/i.test(userAgent);
+  const isAndroid = /Android/i.test(userAgent);
+  const isOtherMobile = /webOS|BlackBerry/i.test(userAgent);
+
+  return {
+    isMobile,
+    isIOS,
+    isAndroid,
+    isOtherMobile
+  };
 };


### PR DESCRIPTION
## Issue Number: #285 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- `Notification.Permission`에서 모바일 기기 제외합니다(https://github.com/GooJinSun/diivers/pull/286#pullrequestreview-1386645872)

## Preview Image
- ios safari, mac chrome에서 테스트 완료
<img width="1278" alt="image" src="https://user-images.githubusercontent.com/37523788/232263603-a9f410ad-655f-40a9-b0dc-6cff3e1700b8.png">

![IMG_F3699CE8A278-1](https://user-images.githubusercontent.com/37523788/232263589-d1261663-e515-4df5-97e3-3c03f0e9d531.jpeg)

## Further comments
