### PR TITLE
(#211) [New Feature] FCM 노티 다국어 지원

### DIFF
--- a/backend/adoorback/notification/models.py
+++ b/backend/adoorback/notification/models.py
@@ -84,7 +84,9 @@ def send_firebase_notification(created, instance, **kwargs):
 
     message = Message(
         data = {
-            'body' : instance.message,
+            'body': instance.message,
+            'message_en': instance.message_en,
+            'message_ko': instance.message_ko,
             'url': instance.redirect_url,
             'tag': str(instance.id),
             'type': 'new',

--- a/frontend/public/firebase-messaging-sw.js
+++ b/frontend/public/firebase-messaging-sw.js
@@ -39,10 +39,11 @@ self.addEventListener('notificationclick', (e) => {
 const messaging = firebase.messaging();
 
 messaging.onBackgroundMessage((payload) => {
-  const { body, tag, url, type } = payload.data;
+  const { message_en, message_ko, url, tag, type } = payload.data;
   const title = 'Diivers';
+
   const options = {
-    body,
+    body: self.navigator.language === 'ko' ? message_ko : message_en,
     tag,
     icon: 'https://diivers.world/assets/logo/full-logo.svg',
     data: {

--- a/frontend/src/utils/firebaseHelpers.js
+++ b/frontend/src/utils/firebaseHelpers.js
@@ -1,5 +1,6 @@
 import axios from '@utils/api';
 import { getToken, onMessage } from 'firebase/messaging';
+import i18n from '@i18n';
 
 // Your web app's Firebase configuration
 export const firebaseConfig = {
@@ -63,10 +64,10 @@ export const deactivateFirebaseDevice = (token) => {
 
 export const addForegroundMessageEventListener = (messaging) => {
   onMessage(messaging, (payload) => {
-    const { body, url, tag, type } = payload.data;
+    const { message_en, message_ko, url, tag, type } = payload.data;
     const title = 'Diivers';
     const options = {
-      body,
+      body: i18n.language === 'ko' ? message_ko : message_en,
       tag,
       icon: 'https://diivers.world/assets/logo/full-logo.svg',
       data: {


### PR DESCRIPTION
## Issue Number: #211

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- FCM 노티 다국어 지원
  - 서버에서 fcm 노티 생성시 영어/한국어 버전의 노티 message 를 보내도록 수정(7c8780a3123e4d7a3ff49d12d448b17ef82d8bec)
    - 아직 body를 사용하고 있을 앱을 위해 `body`는 남겨둡니다
- FCM 포그라운드 메시지 다국어 지원 2ddf3b659e3904a959495f531575b640fb7b599d
- FCM 백그라운드 메시지(서비스워커) 다국어 지원 0ccb4f6d014cd5d6173763b035640aa28fd1afbe
## Preview Image
(왼쪽은 크롬, test 계정, 브라우저 영어 세팅 / 오른쪽은 웨일, sunny 계정, 브라우저 한국어 세팅)
- 영어
![Apr-22-2023 11-56-24](https://user-images.githubusercontent.com/37523788/233758288-1f17295e-141a-463b-8176-fef469b5e149.gif)
- 한국어
![Apr-22-2023 11-58-10](https://user-images.githubusercontent.com/37523788/233758347-6736a651-27d2-4f2b-b6b5-c515a9cdfaf2.gif)
