### PR TITLE
(#151) [회원가입][프론트엔드] 비밀번호 형식 제한 문구 노출

### DIFF
--- a/frontend/src/components/reset-password/ResetPassword.jsx
+++ b/frontend/src/components/reset-password/ResetPassword.jsx
@@ -7,6 +7,7 @@ import { AuthentiCationWrapper } from '@styles/wrappers';
 import { CommonButton, AuthSubButton } from '@styles/buttons';
 import { CommonInput } from '@styles/inputs';
 import { useTranslation } from 'react-i18next';
+import { ConstraintsMessage, WarningMessage } from '../../styles/messages';
 
 export default function ResetPassword() {
   const history = useHistory();
@@ -18,6 +19,7 @@ export default function ResetPassword() {
   const [passwordInfo, setPasswordInfo] = useState({ password: '' });
   const [isResetPasswordSuccess, setIsResetPasswordSuccess] = useState(false);
   const [isResetPasswordFail, setIsResetPasswordFail] = useState(false);
+  const [invalidPasswordMsg, setInvalidPasswordMsg] = useState();
 
   const [t] = useTranslation('translation', { keyPrefix: 'reset_password' });
 
@@ -35,13 +37,18 @@ export default function ResetPassword() {
     setIsResetPasswordFail(resetPasswordStatus === 'FAILURE');
   }, [resetPasswordStatus]);
 
+  const { resetPasswordError } = useSelector((state) => state.userReducer);
+  useEffect(() => {
+    setInvalidPasswordMsg(resetPasswordError?.password);
+  }, [resetPasswordError?.password]);
+
   const handleChange = (e) => {
     setPasswordInfo({ password: e.target.value });
+    setIsResetPasswordFail(false);
+    setInvalidPasswordMsg(undefined);
   };
 
   const onClickSubmitButton = () => {
-    setIsResetPasswordSuccess(false);
-    setIsResetPasswordFail(false);
     dispatch(requestResetPassword(id, token, passwordInfo));
   };
 
@@ -55,7 +62,7 @@ export default function ResetPassword() {
     <AuthentiCationWrapper>
       {isResetPasswordSuccess ? (
         <div>{t('password_initialization_is_complete')}</div>
-      ) : isResetPasswordFail ? (
+      ) : isResetPasswordFail && !invalidPasswordMsg ? (
         <div>{t('invalid_link')}</div>
       ) : (
         <div>
@@ -68,7 +75,13 @@ export default function ResetPassword() {
             type="password"
             onChange={handleChange}
             onKeyDown={onKeySubmit}
+            invalid={invalidPasswordMsg}
           />
+          {invalidPasswordMsg ? (
+            <WarningMessage>{invalidPasswordMsg}</WarningMessage>
+          ) : (
+            <ConstraintsMessage>{t('password_constraints')}</ConstraintsMessage>
+          )}
           <CommonButton
             id="submit-button"
             disabled={passwordInfo.password === ''}

--- a/frontend/src/components/sign-up/SignUp.jsx
+++ b/frontend/src/components/sign-up/SignUp.jsx
@@ -8,7 +8,7 @@ import AuthenticationDesc from '@common-components/authentication-desc/Authentic
 import MoreAboutDiiversModal from '@common-components/more-about-diivers-modal/MoreAboutDiiversModal';
 import { openHTML } from '@utils/openHTML';
 import { CommonInput } from '@styles/inputs';
-import { WarningMessage } from '@styles/messages';
+import { WarningMessage, ConstraintsMessage } from '@styles/messages';
 import RemoveIcon from '@material-ui/icons/RemoveCircle';
 import { useTranslation } from 'react-i18next';
 import { CircularProgress } from '@material-ui/core';
@@ -204,8 +204,10 @@ export default function SignUp() {
           onKeyDown={onKeySubmit}
           invalid={isSubmitted && isPasswordInvalid}
         />
-        {isSubmitted && isPasswordInvalid && (
+        {isSubmitted && isPasswordInvalid ? (
           <WarningMessage>{signUpError.password}</WarningMessage>
+        ) : (
+          <ConstraintsMessage>{t('password_constraints')}</ConstraintsMessage>
         )}
         <ProfileImageUploadWrapper>
           <ProfileImageUploadButton onClick={handleClick}>

--- a/frontend/src/components/sign-up/SignUp.jsx
+++ b/frontend/src/components/sign-up/SignUp.jsx
@@ -46,6 +46,7 @@ export default function SignUp() {
   const [isUsernameInvalid, setIsUsernameInvalid] = useState(false);
   const [isEmailInvalid, setIsEmailInvalid] = useState(false);
   const [isInactiveUser, setIsInactiveUser] = useState(false);
+  const [isPasswordInvalid, setIsPasswordInvalid] = useState(false);
 
   const isSignUpLoading =
     useSelector((state) => state.loadingReducer['user/SIGN_UP']) === 'REQUEST';
@@ -68,21 +69,22 @@ export default function SignUp() {
     if (!isSubmitted || !signUpError) return;
 
     if (
-      signUpError.detail.includes('Username') ||
-      signUpError.detail.includes('닉네임')
+      signUpError.detail?.includes('Username') ||
+      signUpError.detail?.includes('닉네임')
     )
       setIsUsernameInvalid(true);
     if (
-      signUpError.detail.includes('active') ||
-      signUpError.detail.includes('인증')
+      signUpError.detail?.includes('active') ||
+      signUpError.detail?.includes('인증')
     )
       setIsInactiveUser(true);
     if (
-      signUpError.detail.includes('email') ||
-      signUpError.detail.includes('Email') ||
-      signUpError.detail.includes('이메일')
+      signUpError.detail?.includes('email') ||
+      signUpError.detail?.includes('Email') ||
+      signUpError.detail?.includes('이메일')
     )
       setIsEmailInvalid(true);
+    if (signUpError.password) setIsPasswordInvalid(true);
   }, [isSubmitted, signUpError]);
 
   const [signUpInfo, setSignUpInfo] = useState({
@@ -106,6 +108,7 @@ export default function SignUp() {
     setIsUsernameInvalid(false);
     setIsEmailInvalid(false);
     setIsInactiveUser(false);
+    setIsPasswordInvalid(false);
   };
 
   const onInputChange = (e) => {
@@ -199,7 +202,11 @@ export default function SignUp() {
           placeholder={t('password')}
           onChange={onInputChange}
           onKeyDown={onKeySubmit}
+          invalid={isSubmitted && isPasswordInvalid}
         />
+        {isSubmitted && isPasswordInvalid && (
+          <WarningMessage>{signUpError.password}</WarningMessage>
+        )}
         <ProfileImageUploadWrapper>
           <ProfileImageUploadButton onClick={handleClick}>
             {t('upload_profile_image')}

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -55,7 +55,8 @@
     "terms_and_privacy": "Terms and Privacy",
     "consent_to_participate_in_the study": "Consent to participate in the study",
     "learn_more_about_Diivers": "Learn more about Diivers",
-    "image_size_is_too_large":"Image size is too large.\nPlease use an image of 400 * 400 or less."
+    "image_size_is_too_large":"Image size is too large.\nPlease use an image of 400 * 400 or less.",
+    "password_constraints": "The password must be at least 8 characters with a mix of upper and lowercase letters, numbers and symbols"
   },
   "more_about_diivers": {
     "learn_more_about_Diivers":"Learn more about Diivers",

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -56,7 +56,7 @@
     "consent_to_participate_in_the study": "Consent to participate in the study",
     "learn_more_about_Diivers": "Learn more about Diivers",
     "image_size_is_too_large":"Image size is too large.\nPlease use an image of 400 * 400 or less.",
-    "password_constraints": "The password must be at least 8 characters with a mix of upper and lowercase letters, numbers and symbols"
+    "password_constraints": "The password must be at least 8 characters with a mix of upper and lowercase letters, numbers and symbols."
   },
   "more_about_diivers": {
     "learn_more_about_Diivers":"Learn more about Diivers",
@@ -98,7 +98,8 @@
     "invalid_link": "Invalid link.",
     "change_password": "Change Password",
     "password": "password",
-    "login": "Login"
+    "login": "Login",
+    "password_constraints": "The password must be at least 8 characters with a mix of upper and lowercase letters, numbers and symbols."
   },
   "question_selection": {
     "diivers_recommends_new_questions_every_day": "Diivers recommends new questions every day!",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -55,7 +55,8 @@
     "terms_and_privacy": "개인정보 수집 및 이용",
     "consent_to_participate_in_the_study": "연구 참여 동의 완료",
     "learn_more_about_Diivers": "다이버스에 대해 더 알아보기",
-    "image_size_is_too_large":"이미지의 크기가 너무 큽니다.\n400 * 400 이하 크기의 이미지를 사용해주세요"
+    "image_size_is_too_large":"이미지의 크기가 너무 큽니다.\n400 * 400 이하 크기의 이미지를 사용해주세요",
+    "password_constraints": "비밀번호는 알파벳 대/소문자, 숫자, 특수문자를 조합하여 8자 이상으로 입력해주세요."
   },
   "more_about_diivers": {
     "learn_more_about_Diivers":"다이버스에 대해 더 알아보기",

--- a/frontend/src/i18n/locales/ko/translation.json
+++ b/frontend/src/i18n/locales/ko/translation.json
@@ -98,7 +98,8 @@
     "invalid_link": "유효하지 않은 링크입니다.",
     "change_password": "비밀번호 변경",
     "password": "비밀번호",
-    "login": "로그인"
+    "login": "로그인",
+    "password_constraints": "비밀번호는 알파벳 대/소문자, 숫자, 특수문자를 조합하여 8자 이상으로 입력해주세요."
   },
   "question_selection": {
     "diivers_recommends_new_questions_every_day": "Diivers는 매일 새로운 질문을 추천해드립니다!",

--- a/frontend/src/modules/user/index.js
+++ b/frontend/src/modules/user/index.js
@@ -64,7 +64,8 @@ const initialState = {
   selectedUser: null,
   selectQuestion: true,
   fcmToken: null,
-  profileImageUpdatedAt: Date.now()
+  profileImageUpdatedAt: Date.now(),
+  resetPasswordError: null
 };
 
 export const skipOrCompleteSelectQuestions = () => {
@@ -145,7 +146,7 @@ export const requestResetPassword = (id, token, passwordInfo) => {
       await axios.patch(`user/reset-password/${id}/${token}/`, passwordInfo);
       dispatch({ type: RESET_PASSWORD_SUCCESS });
     } catch (error) {
-      dispatch({ type: RESET_PASSWORD_FAILURE });
+      dispatch({ type: RESET_PASSWORD_FAILURE, error: error.response?.data });
     }
   };
 };
@@ -374,6 +375,16 @@ export default function userReducer(state, action) {
         profileImageUpdatedAt: action.profileImageUpdatedAt
       };
     }
+    case RESET_PASSWORD_SUCCESS:
+      return {
+        ...state,
+        resetPasswordError: null
+      };
+    case RESET_PASSWORD_FAILURE:
+      return {
+        ...state,
+        resetPasswordError: action.error
+      };
     default:
       return state;
   }

--- a/frontend/src/styles/messages.js
+++ b/frontend/src/styles/messages.js
@@ -1,12 +1,14 @@
 import styled from 'styled-components';
 
-export const WarningMessage = styled.div`
+const CommonMessage = styled.div`
   font-size: 14px;
-  color: #ff395b;
   margin-bottom: 4px;
 `;
 
-export const ConstraintsMessage = styled.div`
-  font-size: 14px;
+export const WarningMessage = styled(CommonMessage)`
+  color: #ff395b;
+`;
+
+export const ConstraintsMessage = styled(CommonMessage)`
   color: #b5b5b5;
 `;

--- a/frontend/src/styles/messages.js
+++ b/frontend/src/styles/messages.js
@@ -5,3 +5,8 @@ export const WarningMessage = styled.div`
   color: #ff395b;
   margin-bottom: 4px;
 `;
+
+export const ConstraintsMessage = styled.div`
+  font-size: 14px;
+  color: #b5b5b5;
+`;


### PR DESCRIPTION
## Issue Number: #151

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 회원가입/비밀번호 변경 페이지
  - 비밀번호 형식 제한에 대한 메시지 노출

    <img width="534" alt="스크린샷 2023-04-22 오후 8 36 38" src="https://user-images.githubusercontent.com/48233023/233782114-64aa6575-da5c-4a03-80bb-21048cdf2e01.png">

    - `placeholder` 보다는 input 창 아래에 문구를 노출하는게 더 좋을 것 같은데 괜찮을까요?

  - 비밀번호 형식이 맞지 않아 에러가 발생한 경우, 에러 메시지 노출

    <img width="525" alt="스크린샷 2023-04-22 오후 8 38 02" src="https://user-images.githubusercontent.com/48233023/233782268-04a5db62-5859-44a9-afb5-b90159f3a53c.png">

## Preview Image
| 회원가입 페이지 | 비밀번호 변경 페이지 |
| -- | -- |
| ![Apr-22-2023 20-32-29](https://user-images.githubusercontent.com/48233023/233782009-1e3aa31b-063a-4dc5-9110-3eaef2a1d5e9.gif) | ![Apr-22-2023 20-25-00](https://user-images.githubusercontent.com/48233023/233782019-bc330a1e-5409-4a76-9c00-21e1e733ac34.gif) |
