### PR TITLE
(#304) [Bug] 유저 태그 한글 안되는 이슈

### DIFF
--- a/frontend/src/components/_common/new-comment/NewComment.helper.ts
+++ b/frontend/src/components/_common/new-comment/NewComment.helper.ts
@@ -3,7 +3,7 @@
  */
 export const extractTagQuery = (value: string) => {
   // 입력값 value에서 '@'로 시작하는 문자열을 추출하여 matches 배열에 저장한다.
-  const matches = value.match(/@(\w+)/g);
+  const matches = value.match(/@([\p{L}\p{N}_-]+)/gu);
   // matches 배열이 존재하는 경우 마지막 요소의 tagQuery를 추출하여 반환한다.
   if (matches) {
     const lastMatch = matches[matches.length - 1];

--- a/frontend/src/components/_common/new-comment/NewComment.jsx
+++ b/frontend/src/components/_common/new-comment/NewComment.jsx
@@ -52,7 +52,7 @@ export default function NewComment({
   };
 
   useAsyncEffect(async () => {
-    if (!userTagAllowed) return;
+    if (!userTagAllowed || !tagQuery) return;
     const { data } = await axios.get(`/user_tags/search/?query=${tagQuery}`);
     if (data) {
       setUserTagList(data.results);


### PR DESCRIPTION
## Issue Number: #304 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?

tagQuery에서 한글이 인식이 안되는 문제가 있어서 해결
extractTagQuery 함수에서 한글의 경우를 정규식에서 인식하지 않아서 해결

## Preview Image
<img width="383" alt="스크린샷 2023-04-23 오전 12 24 23" src="https://user-images.githubusercontent.com/42240753/233793088-426dbf14-0e10-4935-b145-dfc615f7420e.png">

## Further comments
+ 그리고 tagQuery가 빈 스트링일때 user_tag search API를 호출하지 않도록 아까 처리했다고 생각했는데 반영이 되어있지 않아서 이번에 함께 반영했습니다!