### PR TITLE
(#297) [프로필] 가로로 긴 프로필 사진 업로드 시 여러번 세로로 연속적으로 이어져 업로드 되는 현상

### DIFF
--- a/frontend/src/utils/imageCropHelper.ts
+++ b/frontend/src/utils/imageCropHelper.ts
@@ -7,21 +7,19 @@ export const cropAndResize = (file: File) =>
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
 
-      // 캔버스 크기 설정 및 이미지 중앙에 위치시키기
+      // 이미지의 가로세로 비율(ratio)을 계산하여, 크롭할 영역 계산
       const ratio = Math.min(400 / img.width, 400 / img.height);
-      canvas.width = img.width * ratio;
-      canvas.height = img.height * ratio;
-      ctx?.drawImage(
-        img,
-        0,
-        0,
-        img.width,
-        img.height,
-        (canvas.width - img.width * ratio) / 2,
-        (canvas.height - img.height * ratio) / 2,
-        img.width * ratio,
-        img.height * ratio
-      );
+      const cropWidth = img.width * ratio;
+      const cropHeight = img.height * ratio;
+      const cropX = (img.width - cropWidth) / 2;
+      const cropY = (img.height - cropHeight) / 2;
+
+      // 캔버스 크기 설정
+      canvas.width = 400;
+      canvas.height = 400;
+
+      // 이미지 중앙에 위치시키기
+      ctx?.drawImage(img, cropX, cropY, cropWidth, cropHeight, 0, 0, 400, 400);
 
       // 변환된 Blob 객체 반환
       canvas.toBlob((blob) => {

--- a/frontend/src/utils/imageCropHelper.ts
+++ b/frontend/src/utils/imageCropHelper.ts
@@ -7,19 +7,18 @@ export const cropAndResize = (file: File) =>
       const canvas = document.createElement('canvas');
       const ctx = canvas.getContext('2d');
 
-      // 이미지의 가로세로 비율(ratio)을 계산하여, 크롭할 영역 계산
-      const ratio = Math.min(400 / img.width, 400 / img.height);
-      const cropWidth = img.width * ratio;
-      const cropHeight = img.height * ratio;
+      // 이미지를 적절한 크기로 crop
+      const cropWidth = Math.min(img.width, img.height);
       const cropX = (img.width - cropWidth) / 2;
-      const cropY = (img.height - cropHeight) / 2;
+      const cropY = (img.height - cropWidth) / 2;
 
       // 캔버스 크기 설정
-      canvas.width = 400;
-      canvas.height = 400;
+      const size = 400;
+      canvas.width = size;
+      canvas.height = size;
 
-      // 이미지 중앙에 위치시키기
-      ctx?.drawImage(img, cropX, cropY, cropWidth, cropHeight, 0, 0, 400, 400);
+      // 이미지 리사이즈
+      ctx?.drawImage(img, cropX, cropY, cropWidth, cropWidth, 0, 0, size, size);
 
       // 변환된 Blob 객체 반환
       canvas.toBlob((blob) => {


### PR DESCRIPTION
## Issue Number: #297 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?

imageCropHelper의 cropAndResize 일부 로직을 수정했습니다.
crop된 image가 그려질 canvas의 width, height을 400, 400으로 고정이 되어있지 않아서 해당 이슈가 발생했던 것으로 예상됩니다.

로직은 다음과 같이 변경했습니다.
- img.width, img.height 중 min 값을 찾고,
- 그 크기로 이미지를 크롭한다
- 그리고 canvas의 크기를 400 * 400 으로 잡고
- 그 canvas의 크기에 맞게 크롭된 이미지를 다시 resize 한다

## Preview Image
<img width="311" alt="스크린샷 2023-04-23 오전 1 01 15" src="https://user-images.githubusercontent.com/42240753/233794668-86be22f0-362e-4248-9067-f3780616bae1.png">
<img width="269" alt="스크린샷 2023-04-23 오전 1 01 36" src="https://user-images.githubusercontent.com/42240753/233794687-5d319943-5bba-4de6-967e-336d65153d47.png">

800 * 355 사이즈의 이미지도 첨부된 사진과 같이 적당히 크롭되어 잘 등록되는 것 확인했습니다~!

## Further comments
